### PR TITLE
Add nixos support

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -38,7 +38,7 @@ def host_os_key(rctx):
     else:
         return "%s-%s-%s" % (os, version, arch)
 
-_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn", "raspbian", "pop", "rhel"]
+_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn", "raspbian", "pop", "rhel", "nixos"]
 
 def _linux_dist(rctx):
     res = rctx.execute(["cat", "/etc/os-release"])

--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -113,7 +113,7 @@ def _linux(llvm_version, distname, version, arch):
         os_name = _resolve_version_for_suse(major_llvm_version, llvm_version)
     elif distname == "fedora" and major_llvm_version >= 7:
         os_name = _ubuntu_osname(arch, "20.04", major_llvm_version, llvm_version)
-    elif distname in ["arch", "manjaro"]:
+    elif distname in ["arch", "manjaro", "nixos"]:
         os_name = _ubuntu_osname(arch, "20.04", major_llvm_version, llvm_version)
     elif distname == "amzn":
         # Based on the ID_LIKE field, sles seems like the closest available


### PR DESCRIPTION
Hi!

I would like to work on adding support to nixos. Toghether with this introductory PR, I have a quick question. On of the issues I have now when using the latest toolchain is:
```
	File "/home/lromor/.cache/bazel/_bazel_lromor/38bd39a93dc2b485b8f35263fd6e2b00/external/rules_cc/cc/find_cc_toolchain.bzl", line 68, column 13, in find_cc_toolchain
		fail("In order to use find_cc_toolchain, your rule has to depend on C++ toolchain. See find_cc_toolchain.bzl docs for details.")
Error in fail: In order to use find_cc_toolchain, your rule has to depend on C++ toolchain. See find_cc_toolchain.bzl docs for details.
```

Do tou have any clues on how to fix this? Is it something fixable in the repo or does it require I wrap cc_* rules with my own that uses the default_toolcain() function?

