### PR TITLE
Resolve `Label`s for toolchain roots and sysroots correctly under `bzlmod`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,18 +74,27 @@ jobs:
             ubuntu_22_04,
             linux_sysroot,
           ]
+        bzlmod: [true, false]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test
         run: tests/scripts/${{ matrix.script }}_test.sh
   xcompile_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        bzlmod: [true, false]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test
         run: tests/scripts/run_xcompile_tests.sh
   abs_paths_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        bzlmod: [true, false]
     runs-on: ubuntu-latest
     steps:
       - name: Install APT packages
@@ -94,6 +103,10 @@ jobs:
       - name: Test
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_absolute_paths//:cc-toolchain-x86_64-linux
   sys_paths_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        bzlmod: [true, false]
     runs-on: ubuntu-latest
     steps:
       - name: Install APT packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test
+        env:
+          USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/${{ matrix.script }}_test.sh
   xcompile_test:
     strategy:
@@ -89,6 +91,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Test
+        env:
+          USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_xcompile_tests.sh
   abs_paths_test:
     strategy:
@@ -101,6 +105,8 @@ jobs:
         run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v4
       - name: Test
+        env:
+          USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_absolute_paths//:cc-toolchain-x86_64-linux
   sys_paths_test:
     strategy:
@@ -120,4 +126,6 @@ jobs:
           local_path: /opt/llvm-16
         run: wget --no-verbose "https://github.com/llvm/llvm-project/releases/download/${release}/${archive}${ext}" && tar -xf "${archive}${ext}" && mv "${archive}" "${local_path}"
       - name: Test
+        env:
+          USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ The following mechanisms are available for using an LLVM toolchain:
    the archive is downloaded and extracted as a separate repository with the
    suffix `_llvm`.
 3. You can also specify your own bazel package paths or local absolute paths
-   for each host os-arch pair through the `toolchain_roots` attribute. Note
+   for each host os-arch pair through the `toolchain_roots` attribute (without
+   bzlmod) or the `toolchain_root` module extension tags (with bzlmod). Note
    that the keys here are different and less granular than the keys in the `urls`
    attribute. When using a bazel package path, each of the values is typically
    a package in the user's workspace or configured through `local_repository` or
@@ -132,11 +133,12 @@ The following mechanisms are available for using an LLVM toolchain:
 
 ### Sysroots
 
-A sysroot can be specified through the `sysroot` attribute. This can be either
-a path on the user's system, or a bazel `filegroup` like label. One way to
-create a sysroot is to use `docker export` to get a single archive of the
-entire filesystem for the image you want. Another way is to use the build
-scripts provided by the [Chromium
+A sysroot can be specified through the `sysroot` attribute (without bzlmod) or
+the `sysroot` module extension tag (with bzlmod). This can be either a path on
+the user's system, or a bazel `filegroup` like label. One way to create a
+sysroot is to use `docker export` to get a single archive of the entire
+filesystem for the image you want. Another way is to use the build scripts
+provided by the [Chromium
 project](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/linux/sysroot.md).
 
 ### Cross-compilation

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -56,8 +56,6 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # When updating this version, also update the versions associated with
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
-LLVM_VERSION = "15.0.6"
-
 LLVM_VERSIONS = {
     "": "16.0.0",
     "darwin-aarch64": "16.0.5",
@@ -113,7 +111,7 @@ use_repo(llvm, "llvm_toolchain_13_0_0")
 llvm.toolchain(
     name = "llvm_toolchain_with_absolute_paths",
     absolute_paths = True,
-    llvm_version = LLVM_VERSION,
+    llvm_versions = LLVM_VERSIONS,
 )
 # We can share the downloaded LLVM distribution with the first configuration.
 llvm.toolchain_root(
@@ -125,7 +123,7 @@ use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 # Toolchain example with system LLVM; tested in GitHub CI.
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_version = LLVM_VERSION,
+    llvm_versions = LLVM_VERSIONS,
 )
 # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
 llvm.toolchain_root(

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -114,10 +114,11 @@ llvm.toolchain(
     name = "llvm_toolchain_with_absolute_paths",
     absolute_paths = True,
     llvm_version = LLVM_VERSION,
-    # We can share the downloaded LLVM distribution with the first configuration.
-    toolchain_roots = {
-        "": "@llvm_toolchain_llvm//",
-    },
+)
+# We can share the downloaded LLVM distribution with the first configuration.
+llvm.toolchain_root(
+    name = "llvm_toolchain_with_absolute_paths",
+    label = "@llvm_toolchain_llvm//:BUILD",
 )
 use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 
@@ -125,8 +126,11 @@ use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
     llvm_version = LLVM_VERSION,
-    # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
-    toolchain_roots = {"": "/opt/llvm-16"},
+)
+# For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
+llvm.toolchain_root(
+    name = "llvm_toolchain_with_system_llvm",
+    path = "/opt/llvm-16",
 )
 use_repo(llvm, "llvm_toolchain_with_system_llvm")
 
@@ -134,14 +138,15 @@ use_repo(llvm, "llvm_toolchain_with_system_llvm")
 llvm.toolchain(
     name = "llvm_toolchain_with_sysroot",
     llvm_versions = LLVM_VERSIONS,
-    sysroot = {
-        # TODO: Use an apparent repo name after #234 has been fixed.
-        "linux-x86_64": "@@org_chromium_sysroot_linux_x64//:sysroot",
-    },
-    # We can share the downloaded LLVM distribution with the first configuration.
-    toolchain_roots = {
-        # TODO: Use an apparent repo name after #234 has been fixed.
-        "": "@@toolchains_llvm~~llvm~llvm_toolchain_llvm//",
-    },
+)
+# We can share the downloaded LLVM distribution with the first configuration.
+llvm.toolchain_root(
+    name = "llvm_toolchain_with_sysroot",
+    label = "@llvm_toolchain_llvm//:BUILD",
+)
+llvm.sysroot(
+    name = "llvm_toolchain_with_sysroot",
+    targets = ["linux-x86_64"],
+    label = "@@org_chromium_sysroot_linux_x64//:sysroot",
 )
 use_repo(llvm, "llvm_toolchain_with_sysroot")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -29,8 +29,6 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 # When updating this version, also update the versions associated with
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
-LLVM_VERSION = "16.0.0"
-
 LLVM_VERSIONS = {
     "": "16.0.0",
     "darwin-aarch64": "16.0.5",
@@ -81,7 +79,7 @@ llvm_register_toolchains()
 llvm_toolchain(
     name = "llvm_toolchain_with_absolute_paths",
     absolute_paths = True,
-    llvm_version = LLVM_VERSION,
+    llvm_versions = LLVM_VERSIONS,
     # We can share the downloaded LLVM distribution with the first configuration.
     toolchain_roots = {
         "": "@llvm_toolchain_llvm//",
@@ -91,7 +89,7 @@ llvm_toolchain(
 ## Toolchain example with system LLVM; tested in GitHub CI.
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_version = LLVM_VERSION,
+    llvm_versions = LLVM_VERSIONS,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )

--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -27,7 +27,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Run tests

--- a/tests/scripts/bazel.sh
+++ b/tests/scripts/bazel.sh
@@ -48,6 +48,7 @@ common_test_args=(
   "--show_progress_rate_limit=30"
   "--keep_going"
   "--test_output=errors"
+  "--features=layering_check"
 )
 
 # Do not run autoconf to configure local CC toolchains.

--- a/tests/scripts/bazel.sh
+++ b/tests/scripts/bazel.sh
@@ -37,7 +37,7 @@ bazel="${TMPDIR:-/tmp}/bazelisk"
 readonly bazel
 
 common_args=(
-  "--enable_bzlmod=${USE_BZLMOD:-false}"
+  "--enable_bzlmod=${USE_BZLMOD:-true}"
 )
 
 # shellcheck disable=SC2034

--- a/tests/scripts/centos_test.sh
+++ b/tests/scripts/centos_test.sh
@@ -30,7 +30,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Need system glibc and headers.

--- a/tests/scripts/debian_test.sh
+++ b/tests/scripts/debian_test.sh
@@ -24,7 +24,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/tests/scripts/fedora_test.sh
+++ b/tests/scripts/fedora_test.sh
@@ -24,7 +24,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Need system glibc headers (e.g. features.h).

--- a/tests/scripts/linux_sysroot_test.sh
+++ b/tests/scripts/linux_sysroot_test.sh
@@ -24,7 +24,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/tests/scripts/suse_leap_test.sh
+++ b/tests/scripts/suse_leap_test.sh
@@ -29,7 +29,7 @@ echo "git root: ${git_root}"
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash ---env USE_BZLMOD -volume="${git_root}:/src" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/tests/scripts/suse_leap_test.sh
+++ b/tests/scripts/suse_leap_test.sh
@@ -29,7 +29,7 @@ echo "git root: ${git_root}"
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash ---env USE_BZLMOD -volume="${git_root}:/src" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD -volume="${git_root}:/src" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/tests/scripts/suse_tumbleweed_test.sh
+++ b/tests/scripts/suse_tumbleweed_test.sh
@@ -29,7 +29,7 @@ echo "git root: ${git_root}"
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/tests/scripts/ubuntu_20_04_test.sh
+++ b/tests/scripts/ubuntu_20_04_test.sh
@@ -24,7 +24,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/tests/scripts/ubuntu_22_04_test.sh
+++ b/tests/scripts/ubuntu_22_04_test.sh
@@ -24,7 +24,7 @@ readonly git_root
 
 for image in "${images[@]}"; do
   docker pull "${image}"
-  docker run --rm --entrypoint=/bin/bash --volume="${git_root}:/src:ro" "${image}" -c """
+  docker run --rm --entrypoint=/bin/bash --env USE_BZLMOD --volume="${git_root}:/src:ro" "${image}" -c """
 set -exuo pipefail
 
 # Common setup

--- a/toolchain/extensions/llvm.bzl
+++ b/toolchain/extensions/llvm.bzl
@@ -6,20 +6,61 @@ load(
     _llvm_config_attrs = "llvm_config_attrs",
     _llvm_repo_attrs = "llvm_repo_attrs",
 )
+load(
+    "//toolchain/internal:common.bzl",
+    _is_absolute_path = "is_absolute_path",
+)
+
+def _root_dict(roots, cls, name, strip_target):
+    res = {}
+    for root in roots:
+        targets = list(root.targets)
+        if not targets:
+            targets = [""]
+        for target in targets:
+            if res.get(target):
+                fail("duplicate target '%s' found for %s with name '%s'" % (target, cls, name))
+            if bool(root.path) == (root.label):
+                fail("target '%s' for %s with name '%s' must have either path or label, but not both" % (target, cls, name))
+            if root.path:
+                if not _is_absolute_path(root.path):
+                    fail("target '%s' for %s with name '%s' must have an absolute path value" % (target, cls, name))
+                res.update([(target, root.path)])
+                continue
+            label_str = str(root.label)
+            if strip_target:
+                label_str = label_str.split(":")[0]
+            res.update([(target, label_str)])
+
+    return res
 
 def _llvm_impl_(module_ctx):
     for mod in module_ctx.modules:
         if not mod.is_root:
             fail("Only the root module can use the 'llvm' extension")
+        toolchain_names = []
         for toolchain_attr in mod.tags.toolchain:
+            name = toolchain_attr.name
+            toolchain_names.append(name)
             attrs = {
                 key: getattr(toolchain_attr, key)
                 for key in dir(toolchain_attr)
                 if not key.startswith("_")
             }
+            attrs["toolchain_roots"] = _root_dict([root for root in mod.tags.toolchain_root if root.name == name], "toolchain_root", name, True)
+            attrs["sysroot"] = _root_dict([sysroot for sysroot in mod.tags.sysroot if sysroot.name == name], "sysroot", name, False)
+
             llvm_toolchain(
                 **attrs
             )
+
+        # Check that every defined toolchain_root or sysroot has a corresponding toolchain.
+        for root in mod.tags.toolchain_root:
+            if root.name not in toolchain_names:
+                fail("toolchain_root '%s' does not have a corresponding toolchain" % root.name)
+        for root in mod.tags.sysroot:
+            if root.name not in toolchain_names:
+                fail("sysroot '%s' does not have a corresponding toolchain" % root.name)
 
 _attrs = {
     "name": attr.string(doc = """\
@@ -29,11 +70,30 @@ _attrs = {
 _attrs.update(_llvm_config_attrs)
 _attrs.update(_llvm_repo_attrs)
 
+_attrs.pop("toolchain_roots", None)
+_attrs.pop("sysroot", None)
+
 llvm = module_extension(
     implementation = _llvm_impl_,
     tag_classes = {
         "toolchain": tag_class(
             attrs = _attrs,
+        ),
+        "toolchain_root": tag_class(
+            attrs = {
+                "name": attr.string(doc = "Same name as the toolchain tag.", default = "llvm_toolchain"),
+                "targets": attr.string_list(doc = "Specific targets, if any; empty list means this applies to all."),
+                "label": attr.label(doc = "Dummy label whose package path is the toolchain root package."),
+                "path": attr.string(doc = "Absolute path to the toolchain root."),
+            },
+        ),
+        "sysroot": tag_class(
+            attrs = {
+                "name": attr.string(doc = "Same name as the toolchain tag.", default = "llvm_toolchain"),
+                "targets": attr.string_list(doc = "Specific targets, if any; empty list means this applies to all."),
+                "label": attr.label(doc = "Label containing the files with its package path as the sysroot path."),
+                "path": attr.string(doc = "Absolute path to the sysroot."),
+            },
         ),
     },
 )

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -164,6 +164,9 @@ def canonical_dir_path(path):
         return path + "/"
     return path
 
+def is_absolute_path(val):
+    return val and val[0] == "/" and (len(val) == 1 or val[1] != "/")
+
 def pkg_name_from_label(label):
     if label.workspace_name:
         return "@" + label.workspace_name + "//" + label.package

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -24,6 +24,7 @@ load(
     _check_os_arch_keys = "check_os_arch_keys",
     _host_os_arch_dict_value = "host_os_arch_dict_value",
     _host_tools = "host_tools",
+    _is_absolute_path = "is_absolute_path",
     _list_to_string = "list_to_string",
     _os = "os",
     _os_arch_pair = "os_arch_pair",
@@ -60,7 +61,7 @@ def llvm_config_impl(rctx):
     arch = _arch(rctx)
 
     if not rctx.attr.toolchain_roots:
-        toolchain_root = "@@%s_llvm//" % rctx.attr.name if BZLMOD_ENABLED else "@%s_llvm//" % rctx.attr.name
+        toolchain_root = ("@" if BZLMOD_ENABLED else "") + "@%s_llvm//" % rctx.attr.name
     else:
         (_key, toolchain_root) = _host_os_arch_dict_value(rctx, "toolchain_roots")
 
@@ -76,7 +77,7 @@ def llvm_config_impl(rctx):
 
     # Check if the toolchain root is a system path.
     system_llvm = False
-    if toolchain_root[0] == "/" and (len(toolchain_root) == 1 or toolchain_root[1] != "/"):
+    if _is_absolute_path(toolchain_root):
         use_absolute_paths_llvm = True
         system_llvm = True
 

--- a/toolchain/internal/sysroot.bzl
+++ b/toolchain/internal/sysroot.bzl
@@ -15,6 +15,7 @@
 load(
     "//toolchain/internal:common.bzl",
     _canonical_dir_path = "canonical_dir_path",
+    _is_absolute_path = "is_absolute_path",
     _os_arch_pair = "os_arch_pair",
     _pkg_name_from_label = "pkg_name_from_label",
     _pkg_path_from_label = "pkg_path_from_label",
@@ -47,7 +48,7 @@ def _sysroot_path(sysroot_dict, os, arch):
     # If the sysroot is an absolute path, use it as-is. Check for things that
     # start with "/" and not "//" to identify absolute paths, but also support
     # passing the sysroot as "/" to indicate the root directory.
-    if sysroot[0] == "/" and (len(sysroot) == 1 or sysroot[1] != "/"):
+    if _is_absolute_path(sysroot):
         return (sysroot, None)
 
     label = Label(sysroot)


### PR DESCRIPTION
Currently the repo rule and tag class accept string-form labels for toolchain root packages and sysroots. Under `bzlmod` this is problematic because users may pass us labels that point at repos that are not in this module's repo mapping. To support such labels, they need to be passed to us as actual `Label`s (not strings).

This necessitates some (**breaking**) changes to interface for the repo rule and tag class.

---

For `toolchain_roots`:
  - we want to allow 1:many mappings from system specification to toolchain root Label so a `Label -> string` attribute (i.e. `label_keyed_string_dict`) wouldn't work
  - we also still want to support absolute paths so even if we compromised on the 1:many mappings bit, flipping the map wouldn't work

Adding a level of indirection (`toolchain_roots_label_map`) was the least-worst solution I could come up with:
```starlark
    toolchain_roots = {
        "": "previous_llvm_toolchain",
    },
    # Note: this map is "backwards" because there is no `string_keyed_label_dict`...
    toolchain_roots_label_map = {
        "@llvm_toolchain_llvm": "previous_llvm_toolchain",
    },
```

While this is a breaking change, it shouldn't be too bad though; there's no potential for silent errors and the error message provides a good hint about what change needs to be made I think.

---

I've applied a similar change to `sysroot`:
```starlark
    sysroot = {
        "linux-x86_64": "chromium_x64_sysroot",
    },
    sysroot_label_map = {
        "@org_chromium_sysroot_linux_x64//:sysroot": "chromium_x64_sysroot",
    },
```

For `sysroot` I considered just flipping the map since I think forcing a `1:1` mapping would be more acceptable but:
  - this is a potentially more confusing breaking change
  - this would force us to drop support for absolute paths to a sysroot

---

I've also enabled bzlmod-enabled tests for the system paths, absolute paths, and cross tests in CI.

Fixes #234. cc: @steve-261370