### PR TITLE
Do not fail if not matching LLVM toolchain root is found

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -42,17 +42,20 @@ load(
 # workspace builds, there is never a @@ in labels.
 BZLMOD_ENABLED = "@@" in str(Label("//:unused"))
 
+def _empty_repository(rctx):
+    rctx.file("BUILD.bazel")
+    rctx.file("toolchains.bzl", """\
+def llvm_register_toolchains():
+    pass
+""")
+
 def llvm_config_impl(rctx):
     _check_os_arch_keys(rctx.attr.sysroot)
     _check_os_arch_keys(rctx.attr.cxx_builtin_include_directories)
 
     os = _os(rctx)
     if os == "windows":
-        rctx.file("BUILD.bazel")
-        rctx.file("toolchains.bzl", """\
-def llvm_register_toolchains():
-    pass
-""")
+        _empty_repository(rctx)
         return
     arch = _arch(rctx)
 
@@ -65,8 +68,9 @@ def llvm_register_toolchains():
         fail("LLVM toolchain root missing for ({}, {})".format(os, arch))
     (_key, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions")
     if not llvm_version:
-        fail("LLVM version string missing for ({}, {})".format(os, arch))
-
+        # LLVM version missing for (os, arch)
+        _empty_repository(rctx)
+        return
     use_absolute_paths_llvm = rctx.attr.absolute_paths
     use_absolute_paths_sysroot = use_absolute_paths_llvm
 


### PR DESCRIPTION
This fixes one small, but quite important, difference between using the repository rule with or without `bzlmod` enabled.

Example:

```
llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
llvm.toolchain(
    llvm_versions = {
        "linux-aarch64": "17.0.6",
        "linux-x86_64": "17.0.6",
    },
    sha256 = {
        "linux-aarch64": "6dd62762285326f223f40b8e4f2864b5c372de3f7de0731cb7cd55ca5287b75a",
        "linux-x86_64": "884ee67d647d77e58740c1e645649e29ae9e8a6fe87c1376be0f3a30f3cc9ab3",
    },
    stdlib = {
        "linux-aarch64": "stdc++",
        "linux-x86_64": "stdc++",
    },
    strip_prefix = {
        "linux-aarch64": "clang+llvm-17.0.6-aarch64-linux-gnu",
        "linux-x86_64": "clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04",
    },
    urls = {
        "linux-aarch64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-aarch64-linux-gnu.tar.xz"],
        "linux-x86_64": ["https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.6/clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz"],
    },
)
```

and run the following on a Mac host (on which we want to use the Xcode LLVM toolchain from the system).