### PR TITLE
Add support for Oracle Linux

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -34,7 +34,7 @@ def host_os_key(rctx):
     else:
         return "%s-%s-%s" % (os, version, arch)
 
-_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn", "raspbian", "pop", "rhel"]
+_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn", "raspbian", "pop", "rhel", "ol"]
 
 def _linux_dist(rctx):
     res = rctx.execute(["cat", "/etc/os-release"])

--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -137,7 +137,7 @@ def _linux(llvm_version, distname, version, arch):
     elif distname == "raspbian":
         arch = "armv7a"
         os_name = "linux-gnueabihf"
-    elif distname == "rhel":
+    elif distname in ["rhel", "ol"]:
         if 8 <= float(version) and float(version) < 9:
             os_name = _ubuntu_osname(arch, "18.04", major_llvm_version, llvm_version)
         elif float(version) >= 9:


### PR DESCRIPTION
Adds support for Oracle Linux, which should just be treated as RHEL.

`cat /etc/os-release`

```
NAME="Oracle Linux Server"
VERSION="8.9"
ID="ol"
ID_LIKE="fedora"
```

