### PR TITLE
Add support for AlmaLinux

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -34,7 +34,22 @@ def host_os_key(rctx):
     else:
         return "%s-%s-%s" % (os, version, arch)
 
-_known_distros = ["freebsd", "suse", "ubuntu", "arch", "manjaro", "debian", "fedora", "centos", "amzn", "raspbian", "pop", "rhel", "ol"]
+_known_distros = [
+    "freebsd",
+    "suse",
+    "ubuntu",
+    "arch",
+    "manjaro",
+    "debian",
+    "fedora",
+    "centos",
+    "amzn",
+    "raspbian",
+    "pop",
+    "rhel",
+    "ol",
+    "almalinux",
+]
 
 def _linux_dist(rctx):
     info = {}

--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -137,7 +137,7 @@ def _linux(llvm_version, distname, version, arch):
     elif distname == "raspbian":
         arch = "armv7a"
         os_name = "linux-gnueabihf"
-    elif distname in ["rhel", "ol"]:
+    elif distname in ["rhel", "ol", "almalinux"]:
         if 8 <= float(version) and float(version) < 9:
             os_name = _ubuntu_osname(arch, "18.04", major_llvm_version, llvm_version)
         elif float(version) >= 9:


### PR DESCRIPTION
Adds support for `AlmaLinux`, which is the basis of `manylinux_2_28`

It should be treated the same as `rhel`

```
[root@beb818f8869f /]# cat /etc/os-release 
NAME="AlmaLinux"
VERSION="8.9 (Midnight Oncilla)"
ID="almalinux"
ID_LIKE="rhel centos fedora"
VERSION_ID="8.9"
```