### PR TITLE
Support LLD linker for Darwin

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -42,6 +42,7 @@ set -x
 test_args=(
   "--extra_toolchains=${toolchain_name}"
   "--copt=-v"
+  "--linkopt=-Wl,-v"
   "--linkopt=-Wl,-t"
 )
 

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -34,9 +34,7 @@ filegroup(
 
 filegroup(
     name = "ld",
-    srcs = [
-        "bin/ld.lld",
-    ],
+    srcs = glob(["bin/ld.lld", "bin/ld64.lld"]),
 )
 
 filegroup(

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -19,7 +19,6 @@ load(
 load(
     "//toolchain/internal:common.bzl",
     _check_os_arch_keys = "check_os_arch_keys",
-    _host_tools = "host_tools",
     _os_arch_pair = "os_arch_pair",
 )
 
@@ -42,7 +41,7 @@ def cc_toolchain_config(
         wrapper_bin_prefix,
         compiler_configuration,
         cxx_builtin_include_directories,
-        host_tools_info = {}):
+        host_tools_info = {}):  # trunk-ignore(buildifier/unused-variable)
     host_os_arch_key = _os_arch_pair(host_os, host_arch)
     target_os_arch_key = _os_arch_pair(target_os, target_arch)
     _check_os_arch_keys([host_os_arch_key, target_os_arch_key])
@@ -149,10 +148,10 @@ def cc_toolchain_config(
 
     # Linker flags:
     if host_os == "darwin" and not is_xcompile:
-        # lld is experimental for Mach-O, so we use the native ld64 linker.
-        # TODO: How do we cross-compile from Linux to Darwin?
         use_lld = False
+        ld_name = "ld64.lld"
         link_flags.extend([
+            "-fuse-ld=ld64.lld",  # This is converted to absolute path in cc_wrapper.sh
             "-headerpad_max_install_names",
             "-fobjc-link-runtime",
         ])
@@ -171,6 +170,7 @@ def cc_toolchain_config(
         # not an option because it is not a cross-linker, so lld is the
         # only option.
         use_lld = True
+        ld_name = "lld"
         link_flags.extend([
             "-fuse-ld=lld",
             "-Wl,--build-id=md5",
@@ -272,7 +272,7 @@ def cc_toolchain_config(
         "dwp": tools_path_prefix + "llvm-dwp",
         "gcc": wrapper_bin_prefix + "cc_wrapper.sh",
         "gcov": tools_path_prefix + "llvm-profdata",
-        "ld": tools_path_prefix + "ld.lld" if use_lld else _host_tools.get_and_assert(host_tools_info, "ld"),
+        "ld": tools_path_prefix + ld_name,
         "llvm-cov": tools_path_prefix + "llvm-cov",
         "llvm-profdata": tools_path_prefix + "llvm-profdata",
         "nm": tools_path_prefix + "llvm-nm",

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -56,12 +56,14 @@ function parse_option() {
 
 if [[ -f %{toolchain_path_prefix}bin/clang ]]; then
   execroot_path=""
+  execroot_abs_path="${PWD}/"
 elif [[ ${BASH_SOURCE[0]} == "/"* ]]; then
   # Some consumers of `CcToolchainConfigInfo` (e.g. `cmake` from rules_foreign_cc)
   # change CWD and call $CC (this script) with its absolute path.
   # For cases like this, we'll try to find `clang` through an absolute path.
   # This script is at _execroot_/external/_repo_name_/bin/cc_wrapper.sh
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*}/"
+  execroot_abs_path="$(cd "${execroot_path}" && pwd -P)/"
 else
   echo >&2 "ERROR: could not find clang; PWD=\"${PWD}\"; PATH=\"${PATH}\"."
   exit 5
@@ -71,6 +73,8 @@ function sanitize_option() {
   local -r opt=$1
   if [[ ${opt} == */cc_wrapper.sh ]]; then
     printf "%s" "${execroot_path}%{toolchain_path_prefix}bin/clang"
+  elif [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
+    echo "-fuse-ld=${execroot_abs_path}%{toolchain_path_prefix}bin/ld64.lld"
   elif [[ ${opt} =~ ^-fsanitize-(ignore|black)list=[^/] ]]; then
     # shellcheck disable=SC2206
     parts=(${opt/=/ }) # Split flag name and value into array.
@@ -100,26 +104,6 @@ for ((i = 0; i <= $#; i++)); do
     cmd+=("${opt}")
   fi
 done
-
-# On macOS, we use ld as the linker for single-platform builds (i.e., when not
-# cross-compiling). Some applications may remove /usr/bin from PATH before
-# calling this script, which would make /usr/bin/ld unreachable.  For example,
-# rules_rust does not set PATH (unless the user explicitly sets PATH in env
-# through attributes) [1] when calling rustc, and rustc does not replace an
-# unset PATH with a reasonable default either ([2], [3]), which results in CC
-# being called with PATH={sysroot}/{rust_lib}/bin. Note that rules_cc [4] and
-# rules_go [5] do ensure that /usr/bin is in PATH.
-# [1]: https://github.com/bazelbuild/rules_rust/blob/e589105b4e8181dd1d0d8ccaa0cf3267efb06e86/cargo/cargo_build_script.bzl#L66-L68
-# [2]: https://github.com/rust-lang/rust/blob/1c03f0d0ba4fee54b7aa458f4d3ad989d8bf7b34/compiler/rustc_session/src/session.rs#L804-L813
-# [3]: https://github.com/rust-lang/rust/blob/1c03f0d0ba4fee54b7aa458f4d3ad989d8bf7b34/compiler/rustc_codegen_ssa/src/back/link.rs#L640-L645
-# [4]: https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java;l=529;drc=72caead7b428fd50164079956ec368fc54a9567c
-# [5]: https://github.com/bazelbuild/rules_go/blob/63dfd99403076331fef0775d52a8039d502d4115/go/private/context.bzl#L434
-# Let's restore /usr/bin to PATH in such cases. Note that /usr/bin is not a
-# writeable directory on macOS even with sudo privileges, so it should be safe
-# to add it to PATH even when the application wants to use a very strict PATH.
-if [[ ":${PATH}:" != *":/usr/bin:"* ]]; then
-  PATH="${PATH}:/usr/bin"
-fi
 
 # Call the C++ compiler.
 "${cmd[@]}"

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -105,6 +105,26 @@ for ((i = 0; i <= $#; i++)); do
   fi
 done
 
+# On macOS, we use ld as the linker for single-platform builds (i.e., when not
+# cross-compiling). Some applications may remove /usr/bin from PATH before
+# calling this script, which would make /usr/bin/ld unreachable.  For example,
+# rules_rust does not set PATH (unless the user explicitly sets PATH in env
+# through attributes) [1] when calling rustc, and rustc does not replace an
+# unset PATH with a reasonable default either ([2], [3]), which results in CC
+# being called with PATH={sysroot}/{rust_lib}/bin. Note that rules_cc [4] and
+# rules_go [5] do ensure that /usr/bin is in PATH.
+# [1]: https://github.com/bazelbuild/rules_rust/blob/e589105b4e8181dd1d0d8ccaa0cf3267efb06e86/cargo/cargo_build_script.bzl#L66-L68
+# [2]: https://github.com/rust-lang/rust/blob/1c03f0d0ba4fee54b7aa458f4d3ad989d8bf7b34/compiler/rustc_session/src/session.rs#L804-L813
+# [3]: https://github.com/rust-lang/rust/blob/1c03f0d0ba4fee54b7aa458f4d3ad989d8bf7b34/compiler/rustc_codegen_ssa/src/back/link.rs#L640-L645
+# [4]: https://cs.opensource.google/bazel/bazel/+/master:src/main/java/com/google/devtools/build/lib/bazel/rules/BazelRuleClassProvider.java;l=529;drc=72caead7b428fd50164079956ec368fc54a9567c
+# [5]: https://github.com/bazelbuild/rules_go/blob/63dfd99403076331fef0775d52a8039d502d4115/go/private/context.bzl#L434
+# Let's restore /usr/bin to PATH in such cases. Note that /usr/bin is not a
+# writeable directory on macOS even with sudo privileges, so it should be safe
+# to add it to PATH even when the application wants to use a very strict PATH.
+if [[ ":${PATH}:" != *":/usr/bin:"* ]]; then
+  PATH="${PATH}:/usr/bin"
+fi
+
 # Call the C++ compiler.
 "${cmd[@]}"
 


### PR DESCRIPTION
Users can use with `--linkopt=-fuse-ld=ld64.lld` flag.

Eventually, we should make this the default. But only after we hear from some users that it works for their projects. This PR will make it easy for them to test.