### PR TITLE
Replace references of "host" with "exec".

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -15,6 +15,7 @@
 SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "aarch64")]
 
 # Map of tool name to its symlinked name in the tools directory.
+# See tool_paths in toolchain/cc_toolchain_config.bzl.
 _toolchain_tools = {
     name: name
     for name in [
@@ -40,7 +41,7 @@ _toolchain_tools_darwin = {
     "llvm-libtool-darwin": "libtool",
 }
 
-def host_os_key(rctx):
+def exec_os_key(rctx):
     (os, version, arch) = os_version_arch(rctx)
     if version == "":
         return "%s-%s" % (os, arch)
@@ -154,14 +155,14 @@ def check_os_arch_keys(keys):
                 keys = ", ".join(_supported_os_arch),
             ))
 
-def host_os_arch_dict_value(rctx, attr_name, debug = False):
+def exec_os_arch_dict_value(rctx, attr_name, debug = False):
     # Gets a value from a dictionary keyed by host OS and arch.
     # Checks for the more specific key, then the less specific,
     # and finally the empty key as fallback.
     # Returns a tuple of the matching key and value.
 
     d = getattr(rctx.attr, attr_name)
-    key1 = host_os_key(rctx)
+    key1 = exec_os_key(rctx)
     if key1 in d:
         return (key1, d.get(key1))
 
@@ -230,32 +231,3 @@ def toolchain_tools(os):
     if os == "darwin":
         tools.update(_toolchain_tools_darwin)
     return tools
-
-def _get_host_tool_info(rctx, tool_path, tool_key = None):
-    if tool_key == None:
-        tool_key = tool_path
-
-    if tool_path == None or not rctx.path(tool_path).exists:
-        return {}
-
-    return {
-        tool_key: struct(
-            path = tool_path,
-            features = [],
-        ),
-    }
-
-def _extract_tool_path(tool_info):
-    # Have to support structs or dicts:
-    return tool_info.path if type(tool_info) == "struct" else tool_info["path"]
-
-def _get_host_tool(host_tool_info, tool_key):
-    if tool_key in host_tool_info:
-        return _extract_tool_path(host_tool_info[tool_key])
-    else:
-        return None
-
-host_tools = struct(
-    get_tool_info = _get_host_tool_info,
-    get_and_assert = _get_host_tool,
-)

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
-load("//toolchain/internal:common.bzl", _arch = "arch", _attr_dict = "attr_dict", _host_os_arch_dict_value = "host_os_arch_dict_value", _os = "os")
+load("//toolchain/internal:common.bzl", _arch = "arch", _attr_dict = "attr_dict", _exec_os_arch_dict_value = "exec_os_arch_dict_value", _os = "os")
 load("//toolchain/internal:release_name.bzl", _llvm_release_name = "llvm_release_name")
 
 # If a new LLVM version is missing from this list, please add the shasums here
@@ -547,7 +547,7 @@ def download_llvm(rctx):
     return updated_attrs
 
 def _urls(rctx):
-    (key, urls) = _host_os_arch_dict_value(rctx, "urls", debug = False)
+    (key, urls) = _exec_os_arch_dict_value(rctx, "urls", debug = False)
     if not urls:
         print("LLVM archive URLs missing and no default fallback provided; will try 'distribution' attribute")  # buildifier: disable=print
 
@@ -561,7 +561,7 @@ def _get_llvm_version(rctx):
         return rctx.attr.llvm_version
     if not rctx.attr.llvm_versions:
         fail("Neither 'llvm_version' nor 'llvm_versions' given.")
-    (_, llvm_version) = _host_os_arch_dict_value(rctx, "llvm_versions")
+    (_, llvm_version) = _exec_os_arch_dict_value(rctx, "llvm_versions")
     if not llvm_version:
         fail("LLVM version string missing for ({os}, {arch})", os = _os(rctx), arch = _arch(rctx))
     return llvm_version


### PR DESCRIPTION
This properly captures that we actually mean the exec platform in these contexts. Also remove host_tools utils because we can not really do that for the exec platform.
