### PR TITLE
Return, don't fail, when extension used by non-root module

### DIFF
--- a/toolchain/extensions/llvm.bzl
+++ b/toolchain/extensions/llvm.bzl
@@ -37,7 +37,8 @@ def _root_dict(roots, cls, name, strip_target):
 def _llvm_impl_(module_ctx):
     for mod in module_ctx.modules:
         if not mod.is_root:
-            fail("Only the root module can use the 'llvm' extension")
+            # Only the root module can use the 'llvm' extension
+            return
         toolchain_names = []
         for toolchain_attr in mod.tags.toolchain:
             name = toolchain_attr.name


### PR DESCRIPTION
This fixes the following scenario:

- Two bazel modules, both of which depend on toolchains_llvm
- Both modules are bzlmod enabled with `MODULE.bzlmod` files
- Both `MODULE.bzlmod` files specify a llvm toolchain
- The second modules depends on the first via `bazel_dep`

**Expected results**

- the second module can depend on the first, and operations use the llvm toolchain that it defines

**Actual results**

- build fails with `Error in fail: Only the root module can use the 'llvm' extension`

**Resolution**

Instead of failing, we just `return`. This keeps the behaviour of only being able to actually use the `llvm` extension in the root module, but we don't error out.

A more complex but similar example is that from `rules_python` where they will still register the toolchain, but it will not be marked as the default toolchain if it is not called from the root module: https://github.com/bazelbuild/rules_python/blob/main/python/private/bzlmod/python.bzl#L102