### PR TITLE
Add llvm-profdata for coverage data merging

### DIFF
--- a/toolchain/aliases.bzl
+++ b/toolchain/aliases.bzl
@@ -24,4 +24,5 @@ aliased_tools = [
     "clang-format",
     "clang-tidy",
     "llvm-cov",
+    "llvm-profdata",
 ]


### PR DESCRIPTION
To run coverage reports using llvm tooling, we need llvm-profdata to be available, optimally from the original source in Bazel.