### PR TITLE
Fix double slashes for sysroot = /

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -538,7 +538,7 @@ cc_toolchain(
             # system module map.
             dir
             for dir in cxx_builtin_include_directories
-            if _is_hermetic_or_exists(rctx, dir, sysroot_prefix)
+            if _is_hermetic_or_exists(rctx, dir, sysroot_path)
         ]),
         extra_compiler_files = ("\"%s\"," % str(toolchain_info.extra_compiler_files)) if toolchain_info.extra_compiler_files else "",
     )
@@ -581,8 +581,8 @@ native_binary(
         exec_dl_ext = exec_dl_ext,
     )
 
-def _is_hermetic_or_exists(rctx, path, sysroot_prefix):
-    path = path.replace("%sysroot%", sysroot_prefix)
+def _is_hermetic_or_exists(rctx, path, sysroot_path):
+    path = path.replace("%sysroot%", sysroot_path).replace("//", "/")
     if not path.startswith("/"):
         return True
     return rctx.path(path).exists

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -37,7 +37,7 @@ def _system_module_map(ctx):
     for include_dir in ctx.attr.cxx_builtin_include_directories:
         if ctx.attr.sysroot_path and include_dir.startswith("%sysroot%"):
             include_dir = ctx.attr.sysroot_path + include_dir[len("%sysroot%"):]
-        include_dir = paths.normalize(include_dir)
+        include_dir = paths.normalize(include_dir).replace("//", "/")
         if include_dir.startswith("/"):
             absolute_path_dirs.append(include_dir)
         else:


### PR DESCRIPTION
Ideally we could set the paths to `%sysroot%include` when we know that
`%sysroot%` ends with `/`, but bazel validates that the prefix is
actually `%sysroot%/` so we have to keep the extra slash.
