### PR TITLE
Add two more aliased tools

### DIFF
--- a/toolchain/aliases.bzl
+++ b/toolchain/aliases.bzl
@@ -23,6 +23,8 @@ aliased_tools = [
     "clang-apply-replacements",
     "clang-format",
     "clang-tidy",
+    "clangd",
     "llvm-cov",
     "llvm-profdata",
+    "llvm-symbolizer",
 ]


### PR DESCRIPTION
- `clangd` because it's convenient to be able to configure a language client to use the matching version of clangd that the project is compiled with
- `llvm-symbolizer` because it's also convenient