### PR TITLE
Allow explicitly specifying Linux distribution

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -93,9 +93,14 @@ def os_version_arch(rctx):
     _os = os(rctx)
     _arch = arch(rctx)
 
-    if _os == "linux" and not rctx.attr.exec_os:
-        (distname, version) = _linux_dist(rctx)
-        return distname, version, _arch
+    if _os == "linux":
+        if (rctx.attr.exec_linux_distribution == "") != (rctx.attr.exec_linux_distribution_version == ""):
+            fail("Either both or neither of linux_distribution and linux_distribution_version must be set")
+        if rctx.attr.exec_linux_distribution and rctx.attr.exec_linux_distribution_version:
+            return rctx.attr.exec_linux_distribution, rctx.attr.exec_linux_distribution_version, _arch
+        if not rctx.attr.exec_os:
+            (distname, version) = _linux_dist(rctx)
+            return distname, version, _arch
 
     return _os, "", _arch
 

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -23,7 +23,7 @@ load(
 
 _target_pairs = ", ".join(_supported_os_arch_keys())
 
-# Atributes common to both `llvm` and `toolchain` repository rules.
+# Attributes common to both `llvm` and `toolchain` repository rules.
 common_attrs = {
     "llvm_versions": attr.string_dict(
         mandatory = False,
@@ -42,6 +42,20 @@ common_attrs = {
     "exec_arch": attr.string(
         mandatory = False,
         doc = "Execution platform architecture, if different from host arch.",
+    ),
+    "exec_linux_distribution": attr.string(
+        mandatory = False,
+        doc = ("Linux distribution the exec platform is running (or can compatibly run binaries for). " +
+               "This attribute is ignored if exec_os != 'linux', " +
+               "and if it's set so must exec_linux_distribution_verison be. " +
+               "If not set, and both the exec_os and the host platform are linux, " +
+               "an attempt will be made to discover and use the local host platform."),
+    ),
+    "exec_linux_distribution_version": attr.string(
+        mandatory = False,
+        doc = ("The version number corresponding to exec_linux_distribution, " +
+               "in whatever format the distribution uses " +
+               "(e.g. for ubuntu this may be 20.04, for rhel this may be 8.4, etc)."),
     ),
 }
 


### PR DESCRIPTION
Without this, if you want to do remote execution from a non-Linux (or different Linux) platform to a Linux platform, you need to explicitly fill in the URLs attribute.

With this, you can write something like:
```
llvm_toolchain(
    name = "llvm_toolchain_linux_x86_64",
    llvm_version = "14.0.0",
    exec_os = "linux",
    exec_arch = "x86_64",
    exec_linux_distribution = "ubuntu",
    exec_linux_distribution_version = "18.04",
    sysroot = {
        "linux-x86_64": "@org_chromium_sysroot_linux_x64//:sysroot",
    },
)
```

which will work when remote building from macOS, because it won't attempt to read the Linux distribution from `/etc/os-release` which doesn't exist on macOS.