### PR TITLE
Fix support for --incompatible_disallow_empty_glob

### DIFF
--- a/tests/.bazelrc
+++ b/tests/.bazelrc
@@ -1,1 +1,2 @@
+common --incompatible_disallow_empty_glob
 build --features=layering_check

--- a/tests/openssl/openssl.bazel
+++ b/tests/openssl/openssl.bazel
@@ -842,7 +842,7 @@ cc_library(
         "crypto/**/*.h",
         "crypto/include/*.h",
         "include/internal/*.h",
-    ]),
+    ], allow_empty = True),
     hdrs = HDRS + [
         # These are not independent compile units, but are included in other .c files.
         "crypto/LPdir_unix.c",

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -34,10 +34,10 @@ filegroup(
 
 filegroup(
     name = "ld",
-    srcs = glob([
+    srcs = [
         "bin/ld.lld",
         "bin/ld64.lld",
-    ]),
+    ],
 )
 
 filegroup(
@@ -50,7 +50,10 @@ filegroup(
 
 filegroup(
     name = "all_includes",
-    srcs = glob(["include/**"]),
+    srcs = glob(
+        ["include/**"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -34,7 +34,10 @@ filegroup(
 
 filegroup(
     name = "ld",
-    srcs = glob(["bin/ld.lld", "bin/ld64.lld"]),
+    srcs = glob([
+        "bin/ld.lld",
+        "bin/ld64.lld",
+    ]),
 )
 
 filegroup(
@@ -46,8 +49,8 @@ filegroup(
 )
 
 filegroup(
-  name = "all_includes",
-  srcs = glob(["include/**"]),
+    name = "all_includes",
+    srcs = glob(["include/**"]),
 )
 
 filegroup(
@@ -65,6 +68,7 @@ filegroup(
             # clang_rt.*.o supply crtbegin and crtend sections.
             "lib/**/clang_rt.*.o",
         ],
+        allow_empty = True,
         exclude = [
             "lib/libLLVM*.a",
             "lib/libclang*.a",

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -15,11 +15,14 @@
 package(default_visibility = ["//visibility:public"])
 
 # Some targets may need to directly depend on these files.
-exports_files(glob([
-    "bin/*",
-    "lib/*",
-    "include/*",
-]))
+exports_files(glob(
+    [
+        "bin/*",
+        "lib/*",
+        "include/*",
+    ],
+    allow_empty = True,
+))
 
 ## LLVM toolchain files
 


### PR DESCRIPTION
This allows downstream repos to set this flag
