### PR TITLE
feat: windows toolchain for running clang tools

### DIFF
--- a/toolchain/BUILD.llvm_repo_windows
+++ b/toolchain/BUILD.llvm_repo_windows
@@ -1,0 +1,140 @@
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+# Some targets may need to directly depend on these files.
+exports_files(glob([
+    "bin/*",
+    "lib/*",
+    "include/*",
+]))
+
+## LLVM toolchain files
+
+filegroup(
+    name = "clang",
+    srcs = [
+        "bin/clang.exe",
+        "bin/clang++.exe",
+        "bin/clang-cpp.exe",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    srcs = glob(["bin/ld.lld.exe", "bin/ld64.lld.exe"]),
+)
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "include/**/c++/**",
+        "lib/clang/*/include/**",
+    ]),
+)
+
+filegroup(
+  name = "all_includes",
+  srcs = glob(["include/**"]),
+)
+
+filegroup(
+    name = "bin",
+    srcs = glob(["bin/**"]),
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(
+        [
+            "lib/**/lib*.a",
+            "lib/clang/*/lib/**/*.a",
+            "lib/clang/*/lib/**/*.dylib",
+            # clang_rt.*.o supply crtbegin and crtend sections.
+            "lib/**/clang_rt.*.o",
+        ],
+        exclude = [
+            "lib/libLLVM*.a",
+            "lib/libclang*.a",
+            "lib/liblld*.a",
+        ],
+    ),
+    # Include the .dylib files in the linker sandbox even though they will
+    # not be available at runtime to allow sanitizers to work locally.
+    # Any library linked from the toolchain to be released should be linked statically.
+)
+
+filegroup(
+    name = "ar",
+    srcs = ["bin/llvm-ar.exe"],
+)
+
+filegroup(
+    name = "as",
+    srcs = [
+        "bin/clang.exe",
+        "bin/llvm-as.exe",
+    ],
+)
+
+filegroup(
+    name = "nm",
+    srcs = ["bin/llvm-nm.exe"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/llvm-objcopy.exe"],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = ["bin/llvm-objdump.exe"],
+)
+
+filegroup(
+    name = "profdata",
+    srcs = ["bin/llvm-profdata.exe"],
+)
+
+filegroup(
+    name = "dwp",
+    srcs = ["bin/llvm-dwp.exe"],
+)
+
+filegroup(
+    name = "ranlib",
+    srcs = ["bin/llvm-ranlib.exe"],
+)
+
+filegroup(
+    name = "readelf",
+    srcs = ["bin/llvm-readelf.exe"],
+)
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/llvm-strip.exe"],
+)
+
+filegroup(
+    name = "symbolizer",
+    srcs = ["bin/llvm-symbolizer.exe"],
+)
+
+filegroup(
+    name = "clang-tidy",
+    srcs = ["bin/clang-tidy.exe"],
+)

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "aarch64")]
+SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "aarch64"), ("windows", "x86_64")]
 
 # Map of tool name to its symlinked name in the tools directory.
 # See tool_paths in toolchain/cc_toolchain_config.bzl.
@@ -104,7 +104,7 @@ def os(rctx):
 
     name = rctx.attr.exec_os
     if name:
-        if name in ("linux", "darwin"):
+        if name in ("linux", "darwin", "windows"):
             return name
         else:
             fail("Unsupported value for exec_os: %s" % name)
@@ -120,7 +120,7 @@ def os(rctx):
 
 def os_bzl(os):
     # Return the OS string as used in bazel platform constraints.
-    return {"darwin": "osx", "linux": "linux"}[os]
+    return {"darwin": "osx", "linux": "linux", "windows": "windows"}[os]
 
 def arch(rctx):
     arch = rctx.attr.exec_arch

--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -46,6 +46,16 @@ def _darwin(llvm_version, arch):
     )
 
 def _windows(llvm_version, arch):
+    major_llvm_version = _major_llvm_version(llvm_version)
+    if (major_llvm_version >= 18 and arch.endswith("64")):
+        arch = "x86_64"
+        suffix = "pc-windows-msvc"
+        return "clang+llvm-{llvm_version}-{arch}-{suffix}.tar.xz".format(
+            llvm_version = llvm_version,
+            arch = arch,
+            suffix = suffix,
+        )
+
     if arch.endswith("64"):
         win_arch = "win64"
     else:

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -291,14 +291,17 @@ llvm_config_attrs.update({
 def llvm_repo_impl(rctx):
     os = _os(rctx)
     if os == "windows":
-        rctx.file("BUILD.bazel", executable = False)
-        return None
-
-    rctx.file(
-        "BUILD.bazel",
-        content = rctx.read(Label("//toolchain:BUILD.llvm_repo")),
-        executable = False,
-    )
+        rctx.file(
+            "BUILD.bazel",
+            content = rctx.read(Label("//toolchain:BUILD.llvm_repo_windows")),
+            executable = False,
+        )
+    else:
+        rctx.file(
+            "BUILD.bazel",
+            content = rctx.read(Label("//toolchain:BUILD.llvm_repo")),
+            executable = False,
+        )
 
     updated_attrs = _download_llvm(rctx)
 


### PR DESCRIPTION
This is a start on windows toolchain support (https://github.com/bazel-contrib/toolchains_llvm/issues/4). Enough is in place for the distribution to be downloaded, extracted, and tools made available through symlinks and a build file.

working examples:
bazel run @llvm_toolchain_llvm//:bin/clang-tidy.exe
bazel run @llvm_toolchain_llvm//:bin/clang-format.exe

llvm 18+ is required.

Comments, suggestions, help all very welcome