### PR TITLE
Added option to skip linking against `libunwind` 

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -209,8 +209,6 @@ def cc_toolchain_config(
             ])
             libunwind_link_flags = [
                 "-l:libunwind.a",
-                # Compiler runtime features.
-                "-rtlib=compiler-rt",
                 # To support libunwind.
                 "-lpthread",
                 "-ldl",

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -345,7 +345,7 @@ def cc_toolchain_config(
         dbg_compile_flags = dbg_compile_flags,
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
-        link_flags = link_flags + select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags}) +
+        link_flags = link_flags + select({str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags, "//conditions:default": []}) +
                      select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_compiler_rt")): compiler_rt_link_flags}),
         archive_flags = archive_flags,
         link_libs = link_libs,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -142,6 +142,7 @@ def cc_toolchain_config(
     # unused symbols are not stripped.
     link_libs = []
     libunwind_link_flags = []
+    compiler_rt_link_flags = []
 
     # Flags for ar.
     archive_flags = []
@@ -207,6 +208,7 @@ def cc_toolchain_config(
                 "-l:libc++.a",
                 "-l:libc++abi.a",
             ])
+            compiler_rt_link_flags = ["-rtlib=compiler-rt"]
             libunwind_link_flags = [
                 "-l:libunwind.a",
                 # To support libunwind.
@@ -343,7 +345,8 @@ def cc_toolchain_config(
         dbg_compile_flags = dbg_compile_flags,
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
-        link_flags = link_flags + select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags}),
+        link_flags = link_flags + select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags}) +
+                     select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_compiler_rt")): compiler_rt_link_flags}),
         archive_flags = archive_flags,
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -141,6 +141,7 @@ def cc_toolchain_config(
     # Similar to link_flags, but placed later in the command line such that
     # unused symbols are not stripped.
     link_libs = []
+    libunwind_link_flags = []
 
     # Flags for ar.
     archive_flags = []
@@ -205,13 +206,15 @@ def cc_toolchain_config(
             link_flags.extend([
                 "-l:libc++.a",
                 "-l:libc++abi.a",
+            ])
+            libunwind_link_flags = [
                 "-l:libunwind.a",
                 # Compiler runtime features.
                 "-rtlib=compiler-rt",
                 # To support libunwind.
                 "-lpthread",
                 "-ldl",
-            ])
+            ]
         else:
             # Several system libraries on macOS dynamically link libc++ and
             # libc++abi, so static linking them becomes a problem. We need to
@@ -223,11 +226,13 @@ def cc_toolchain_config(
                 "-L{}/usr/lib".format(sysroot_path),
                 "-lc++",
                 "-lc++abi",
-                "-Bstatic",
-                "-lunwind",
                 "-Bdynamic",
                 "-L{}lib".format(toolchain_path_prefix),
             ])
+            libunwind_link_flags = [
+                "-Bstatic",
+                "-lunwind",
+            ]
 
     elif stdlib == "libc++":
         cxx_flags = [
@@ -340,7 +345,7 @@ def cc_toolchain_config(
         dbg_compile_flags = dbg_compile_flags,
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
-        link_flags = link_flags,
+        link_flags = link_flags + select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags}),
         archive_flags = archive_flags,
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -346,7 +346,7 @@ def cc_toolchain_config(
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
         link_flags = link_flags + select({str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags, "//conditions:default": []}) +
-                     select({"//conditions:default": [], str(Label("@toolchains_llvm//toolchain/config:use_compiler_rt")): compiler_rt_link_flags}),
+                     select({str(Label("@toolchains_llvm//toolchain/config:use_compiler_rt")): compiler_rt_link_flags, "//conditions:default": []}),
         archive_flags = archive_flags,
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -20,8 +20,20 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "compiler-rt",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "use_libunwind",
     flag_values = {":libunwind": "True"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "use_compiler_rt",
+    flag_values = {":compiler-rt": "True"},
     visibility = ["//visibility:public"],
 )

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2021 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "libunwind",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "use_libunwind",
+    flag_values = {":libunwind": "True"},
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
It may sometimes be desired not to use `libunwind`.  Added a `bool_flag` that allows the user to disable linking against the `libunwind` library.
    
To disable linking against libunwind use the following command line
parameter:

```
--@toolchains_llvm//toolchain/config:libunwind=False
```