### PR TITLE
Export share/clang/* from llvm_toolchain

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -20,6 +20,7 @@ exports_files(glob(
         "bin/*",
         "lib/*",
         "include/*",
+        "share/clang/*",
     ],
     allow_empty = True,
 ))


### PR DESCRIPTION
This allows us to get access to various scripts such as share/clang/clang-format-diff.