### PR TITLE
Make LLD work with clang18

### DIFF
--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -74,7 +74,7 @@ function sanitize_option() {
   if [[ ${opt} == */cc_wrapper.sh ]]; then
     printf "%s" "${execroot_path}%{toolchain_path_prefix}bin/clang"
   elif [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
-    echo "-fuse-ld=${execroot_abs_path}%{toolchain_path_prefix}bin/ld64.lld"
+    echo "--ld-path=${execroot_abs_path}%{toolchain_path_prefix}bin/ld64.lld"
   elif [[ ${opt} =~ ^-fsanitize-(ignore|black)list=[^/] ]]; then
     # shellcheck disable=SC2206
     parts=(${opt/=/ }) # Split flag name and value into array.
@@ -88,6 +88,9 @@ cmd=()
 for ((i = 0; i <= $#; i++)); do
   if [[ ${!i} == @* ]]; then
     while IFS= read -r opt; do
+      if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
+        cmd+=("-fuse-ld=lld")
+      fi
       opt="$(
         set -e
         sanitize_option "${opt}"


### PR DESCRIPTION
Clang [has custom code](https://github.com/llvm/llvm-project/blob/1193f7d6487d2d94009f8d8d27da3907136482b9/clang/lib/Driver/ToolChains/Darwin.cpp#L358-L360) to inject the `-platform_version` flag when invoking `lld`. [This takes effect ](https://github.com/llvm/llvm-project/blob/1193f7d6487d2d94009f8d8d27da3907136482b9/clang/lib/Driver/ToolChain.cpp#L919-L920)when we pass `-fuse-ld=lld`, which we currently don't do for `lld` because want to point at the hermetic one. Switch to using `--ld-path` instead, which is supported since Clang12.

The current structure relies on `sanitize_option` generating 1 option per input, so I had to add the extra option check in the loop around it. 

This is why LLD didn't work for me [when we first added this support](https://github.com/bazel-contrib/toolchains_llvm/pull/286#issuecomment-1993064612).

Kudos to @keith for the analysis above :)

I think we should follow-up soon and make LLD the default; that should allow a lot of simplification