### PR TITLE
Update apple `release_name` for version >= 18

### DIFF
--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -27,9 +27,14 @@ def _darwin_apple_suffix(llvm_version, arch):
             return "apple-darwin21.0"
         else:
             return "apple-darwin"
-    elif major_llvm_version >= 15:
+    elif major_llvm_version >= 15 and major_llvm_version < 18:
         if arch == "arm64":
             return "apple-darwin22.0"
+        else:
+            return "apple-darwin21.0"
+    elif major_llvm_version >= 18:
+        if arch == "arm64":
+            return "apple-macos11"
         else:
             return "apple-darwin21.0"
     else:


### PR DESCRIPTION
As shown in commit 6c57c24ec0edadb5161999926919d2768096f170, the newer apple releases seem to use `apple-macos11` instead of `apple-darwin22.0`. (Though I am not sure what would be used for x86, since I can't find such a build for llvm version >= 18.)

Also, if this is merged, can we get a new toolchains_llvm release (v1.1.3) shortly after? The most recent apple binary currently available in v1.1.2 is quite old. 