### PR TITLE
Fix release notes template tag.

### DIFF
--- a/.github/workflows/release_notes_template.txt
+++ b/.github/workflows/release_notes_template.txt
@@ -3,7 +3,7 @@ Minimum bazel version: **7.0.0**
 If you're using `bzlmod`, add the following to `MODULE.bazel`:
 
 ```starlark
-bazel_dep(name = "toolchains_llvm", version = "{tag}")
+bazel_dep(name = "toolchains_llvm", version = "{version}")
 
 # Configure and register the toolchain.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")

--- a/.github/workflows/release_notes_template.txt
+++ b/.github/workflows/release_notes_template.txt
@@ -5,14 +5,6 @@ If you're using `bzlmod`, add the following to `MODULE.bazel`:
 ```starlark
 bazel_dep(name = "toolchains_llvm", version = "{tag}")
 
-# To directly use a commit from GitHub, replace commit with the commit you want.
-# Otherwise, omit this block.
-git_override(
-  module_name = "toolchains_llvm",
-  commit = "{commit}",
-  remote = "https://github.com/bazel-contrib/toolchains_llvm",
-)
-
 # Configure and register the toolchain.
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
@@ -23,6 +15,15 @@ use_repo(llvm, "llvm_toolchain")
 # use_repo(llvm, "llvm_toolchain_llvm") # if you depend on specific tools in scripts
 
 register_toolchains("@llvm_toolchain//:all")
+```
+
+To directly use a commit from GitHub, add this block and replace commit with the commit you want.
+```starlark
+git_override(
+  module_name = "toolchains_llvm",
+  commit = "{commit}",
+  remote = "https://github.com/bazel-contrib/toolchains_llvm",
+)
 ```
 
 If not using `bzlmod`, include this section in your `WORKSPACE`:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -16,8 +16,9 @@ sed -i.bak "s/0.0.0/${tag}/" MODULE.bazel && git add MODULE.bazel && git commit 
 git archive --format=tar --prefix="${prefix}/" HEAD | gzip >"${archive}"
 sha=$(shasum -a 256 "${archive}" | cut -f1 -d' ')
 
+# Strip leading "v" from the tag if present.
 sed \
-  -e "s/{tag}/${tag}/g" \
+  -e "s/{tag}/${tag#v}/g" \
   -e "s/{commit}/${commit}/g" \
   -e "s/{prefix}/${prefix}/g" \
   -e "s/{archive}/${archive}/g" \

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -16,9 +16,10 @@ sed -i.bak "s/0.0.0/${tag}/" MODULE.bazel && git add MODULE.bazel && git commit 
 git archive --format=tar --prefix="${prefix}/" HEAD | gzip >"${archive}"
 sha=$(shasum -a 256 "${archive}" | cut -f1 -d' ')
 
-# Strip leading "v" from the tag if present.
+# Strip leading "v" from the tag if present to create the semver version.
 sed \
-  -e "s/{tag}/${tag#v}/g" \
+  -e "s/{version}/${tag#v}/g" \
+  -e "s/{tag}/${tag}/g" \
   -e "s/{commit}/${commit}/g" \
   -e "s/{prefix}/${prefix}/g" \
   -e "s/{archive}/${archive}/g" \


### PR DESCRIPTION
The existing release notes template block can't be pasted into a MODULE.bazel because it generates an invalid semver.  Strip the leading "v".