### PR TITLE
Add dynamic-stdc++

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -273,6 +273,10 @@ def cc_toolchain_config(
             "-std=" + cxx_standard,
             "-stdlib=libstdc++",
         ]
+
+        link_flags.extend([
+            "-lstdc++",
+        ])
     elif stdlib == "stdc++":
         cxx_flags = [
             "-std=" + cxx_standard,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -268,6 +268,11 @@ def cc_toolchain_config(
             "-l:c++.a",
             "-l:c++abi.a",
         ])
+    elif stdlib == "system-stdc++":
+        cxx_flags = [
+            "-std=" + cxx_standard,
+            "-stdlib=libstdc++",
+        ]
     elif stdlib == "stdc++":
         cxx_flags = [
             "-std=" + cxx_standard,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -268,7 +268,7 @@ def cc_toolchain_config(
             "-l:c++.a",
             "-l:c++abi.a",
         ])
-    elif stdlib == "system-stdc++":
+    elif stdlib == "dynamic-stdc++":
         cxx_flags = [
             "-std=" + cxx_standard,
             "-stdlib=libstdc++",


### PR DESCRIPTION
Depending on your project statically linking libstdc++ from your sysroot
might not be viable. For example if you rely on other shared libraries
that link the shared version, linking the static version to a binary
might result in ODR violations. This new `dynamic-stdc++` sets the
compile flags correctly but doesn't force the static version, so the
sysroot's shared version will be preferred.
