### PR TITLE
ci: update `libtinfo5` installation for Ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,9 @@ jobs:
         bzlmod: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: startsWith(matrix.os, 'ubuntu')
-        name: Install APT packages
-        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v4
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: tests/scripts/ubuntu_install_libtinfo.sh
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
@@ -51,10 +50,9 @@ jobs:
         bzlmod: [true, false]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: startsWith(matrix.os, 'ubuntu')
-        name: Install APT packages
-        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v4
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: tests/scripts/ubuntu_install_libtinfo.sh
       - name: Test
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
@@ -102,9 +100,8 @@ jobs:
         bzlmod: [true, false]
     runs-on: ubuntu-latest
     steps:
-      - name: Install APT packages
-        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v4
+      - run: tests/scripts/ubuntu_install_libtinfo.sh
       - name: Test
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
@@ -116,9 +113,8 @@ jobs:
         bzlmod: [true, false]
     runs-on: ubuntu-latest
     steps:
-      - name: Install APT packages
-        run: sudo apt-get -y install libtinfo5
       - uses: actions/checkout@v4
+      - run: tests/scripts/ubuntu_install_libtinfo.sh
       - name: Download and Extract LLVM distribution
         env:
           release: llvmorg-16.0.0

--- a/tests/scripts/ubuntu_install_libtinfo.sh
+++ b/tests/scripts/ubuntu_install_libtinfo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Ubuntu 24.04 does not have libtinfo5 in its PPAs:
+#
+# However, the LLVM binary releases hosted up upstream still target Ubuntu 18.04
+# as of this writing and contain binaries linked against `libtinfo5`.
+#
+# This script installs `libtinfo5` using the `.deb` from Ubuntu 22.04's PPAs:
+# https://packages.ubuntu.com/jammy-updates/amd64/libtinfo5/download
+
+set -euo pipefail
+
+pkg="$(mktemp --suffix=.deb)"
+trap 'rm -f "${pkg}"' EXIT
+
+curl -L https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb -o "${pkg}"
+sudo dpkg -i "${pkg}"


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/10636 `ubuntu-latest` is now Ubuntu 24.04 instead of 22.04 which [does not] have `libtinfo5` in the default PPAs.

[does not]: https://packages.ubuntu.com/search?keywords=libtinfo

Unfortunately all of the LLVM binary releases for Ubuntu still target 18.04 ~~and contain binaries linked against `libtinfo5` — bumping the version of LLVM we use in our tests' toolchains will not solve this problem~~ (see below).

Pinning CI to use Ubuntu 22.04 is an option; however this PR installs `libtinfo5` on the Ubuntu 24.04 runners manually instead.