### PR TITLE
Make sure that only expands existing response files

### DIFF
--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -86,7 +86,7 @@ function sanitize_option() {
 
 cmd=()
 for ((i = 0; i <= $#; i++)); do
-  if [[ ${!i} == @* && -r "${i:1}" ]]; then
+  if [[ ${!i} == @* && -r ${i:1} ]]; then
     while IFS= read -r opt; do
       if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
         cmd+=("-fuse-ld=lld")

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -86,7 +86,7 @@ function sanitize_option() {
 
 cmd=()
 for ((i = 0; i <= $#; i++)); do
-  if [[ ${!i} == @* ]]; then
+  if [[ ${!i} == @* && -r "${i:1}" ]]; then
     while IFS= read -r opt; do
       if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
         cmd+=("-fuse-ld=lld")

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -86,7 +86,7 @@ function sanitize_option() {
 
 cmd=()
 for ((i = 0; i <= $#; i++)); do
-  if [[ ${!i} == @* && -r ${i:1} ]]; then
+  if [[ ${!i} == @* && -r "${i:1}" ]]; then
     while IFS= read -r opt; do
       if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
         cmd+=("-fuse-ld=lld")


### PR DESCRIPTION
Otherwise the parameter is more than likely a prefix of an `@rpath` so it is probably better off leaving as it is.

This simply ports the following fix: https://github.com/bazelbuild/bazel/pull/13148

Resolves bazel-contrib/toolchains_llvm#408