### PR TITLE
Fix shfmt config to disable Bash code simplification

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -44,6 +44,18 @@ lint:
       version_command:
         parse_regex: ${semver}
         run: buildifier --version
+    # Default shfmt config uses -s flag to simplify code but this can cause
+    # unwanted semantic changes
+    - name: shfmt
+      commands:
+        - name: format
+          output: shfmt
+          run: shfmt -w ${target}
+          success_codes: [0, 1]
+          cache_results: true
+          formatter: true
+          batch: true
+          in_place: true
   enabled:
     - actionlint@1.6.25
     - buildifier@7.1.0


### PR DESCRIPTION
I'm @ormandi's colleague and was following #409. It seems the formatter wanting to remove quotes is due to Trunk by default using the `-s` flag for `shfmt` to simplify code. Either there is a bug in `shfmt` that makes it overly aggressive in removing quotes or what it's doing is actually correct, but I'm not enough of a shell expert to tell.

This PR sidesteps the issue by customizes the Trunk config to avoid passing `-s`.