### PR TITLE
fix: Skip cxx_builtin_include_directories filtering when remote

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -115,7 +115,9 @@ def os(rctx):
             return name
         else:
             fail("Unsupported value for exec_os: %s" % name)
+    return os_from_rctx(rctx)
 
+def os_from_rctx(rctx):
     name = rctx.os.name
     if name == "linux":
         return "linux"
@@ -138,7 +140,9 @@ def arch(rctx):
             return "x86_64"
         else:
             fail("Unsupported value for exec_arch: %s" % arch)
+    return arch_from_rctx(rctx)
 
+def arch_from_rctx(rctx):
     arch = rctx.os.arch
     if arch == "arm64":
         return "aarch64"


### PR DESCRIPTION
It is not possible to determine directory existence remotely, so for remote execution the best option is not to filter. This PR addresses https://github.com/bazel-contrib/toolchains_llvm/pull/280/files/1a11e9f0f58f89789b5cd0a389efc7e321e33b3b#r1830121103