### PR TITLE
Remove native-java buildifier warning

### DIFF
--- a/.buildifier.json
+++ b/.buildifier.json
@@ -34,7 +34,6 @@
     "native-android",
     "native-build",
     "native-cc",
-    "native-java",
     "native-package",
     "native-proto",
     "native-py",


### PR DESCRIPTION
This doesn't matter for this repo and has also been split into multiple
in buildifier @ HEAD so it's now invalid
