### PR TITLE
cc_wrapper: Spill arguments back to a response file

### DIFF
--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -60,14 +60,19 @@ function sanitize_option() {
 
 cmd=()
 for ((i = 0; i <= $#; i++)); do
-  if [[ ${!i} == @* ]]; then
+  if [[ ${!i} == @* && -r "${i:1}" ]]; then
+    # Create a temporary file that we'll spill sanitized options to since they
+    # were originally read from a response file.
+    temp_file=$(mktemp)
+
     while IFS= read -r opt; do
       opt="$(
         set -e
         sanitize_option "${opt}"
       )"
-      cmd+=("${opt}")
+      echo "${opt}" >> "${temp_file}"
     done <"${!i:1}"
+    mv "${temp_file}" "${!i:1}"
   else
     opt="$(
       set -e

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -87,6 +87,10 @@ function sanitize_option() {
 cmd=()
 for ((i = 0; i <= $#; i++)); do
   if [[ ${!i} == @* && -r "${i:1}" ]]; then
+    # Create a temporary file that we'll spill sanitized options to since they
+    # were originally read from a response file.
+    temp_file=$(mktemp)
+
     while IFS= read -r opt; do
       if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
         cmd+=("-fuse-ld=lld")
@@ -96,8 +100,9 @@ for ((i = 0; i <= $#; i++)); do
         sanitize_option "${opt}"
       )"
       parse_option "${opt}"
-      cmd+=("${opt}")
+      echo "${opt}" >> "${temp_file}"
     done <"${!i:1}"
+    mv "${temp_file}" "${!i:1}"
   else
     opt="$(
       set -e


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/toolchains_llvm/issues/421

This PR tweaks the `*cc_wraper.sh` scripts to spill command line arguments from response files, back into a file after sanitizing. Previously they were expanded into the `cmd` variable which would then get specified on the command line, possibly leading to an overflow.