### PR TITLE
Add support for extracting zst LLVM distributions

### DIFF
--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -697,7 +697,12 @@ def _distribution_urls(rctx):
 
     sha256 = _llvm_distributions[basename]
 
-    strip_prefix = basename[:(len(basename) - len(".tar.xz"))]
+    if basename.endswith(".tar.xz"):
+        strip_prefix = basename[:(len(basename) - len(".tar.xz"))]
+    elif basename.endswith(".tar.zst"):
+        strip_prefix = basename[:(len(basename) - len(".tar.zst"))]
+    else:
+        fail("Unknown URL file extension {url}", url = basename)
 
     strip_prefix = strip_prefix.rstrip("-rhel86")
 


### PR DESCRIPTION
zstd is a lot faster than xz at decompressing.  Unfortunately, llvm/clang aren't distributed with zstd, so this still takes action to create a binary package, and then add it to _llvm_distributions.