### PR TITLE
cc_toolchain: prefix include directories with `%workspace%`

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -314,7 +314,7 @@ def _cc_toolchain_str(
     # visible via the "built_in_include_directories" attribute of CcToolchainInfo as well as to keep
     # them in sync with the directories included in the system module map generated for the stricter
     # "layering_check" feature.
-    toolchain_path_prefix = toolchain_info.llvm_dist_path_prefix
+    toolchain_path_prefix = "%workspace%/" + toolchain_info.llvm_dist_path_prefix
     llvm_version = toolchain_info.llvm_version
     major_llvm_version = int(llvm_version.split(".")[0])
     target_system_name = {

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -37,6 +37,8 @@ def _system_module_map(ctx):
     for include_dir in ctx.attr.cxx_builtin_include_directories:
         if ctx.attr.sysroot_path and include_dir.startswith("%sysroot%"):
             include_dir = ctx.attr.sysroot_path + include_dir[len("%sysroot%"):]
+        if include_dir.startswith("%workspace%/"):
+            include_dir = include_dir.removeprefix("%workspace%/")
         include_dir = paths.normalize(include_dir).replace("//", "/")
         if include_dir.startswith("/"):
             absolute_path_dirs.append(include_dir)


### PR DESCRIPTION
Today the [`built_in_includes_directores`](https://bazel.build/rules/lib/providers/CcToolchainInfo#built_in_include_directories) that are exported by this toolchain, appear to be incorrect. For example, when using `toolchains_llvm` locally with clang 18.1.8 one of the includes paths is:

```
external/llvm_toolchain/external/llvm_toolchain_llvm/include/aarch64-apple-macosx/c++/v1
```

This path does not exist, it's incorrectly prefixed with `external/llvm_toolchain/`. This is because when [populating the list](https://github.com/bazelbuild/bazel/blob/5665f76c31b8f50a56dc627b89dd3af2515c28b4/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_provider_helper.bzl#L236-L238) of `built_in_includes_directories` Bazel will resolve the included directory based on [these rules](https://github.com/bazelbuild/bazel/blob/5665f76c31b8f50a56dc627b89dd3af2515c28b4/src/main/starlark/builtins_bzl/common/cc/cc_toolchain_provider_helper.bzl#L102-L122). Specifically the rule we're hitting today, and the cause of the invalid prefixing is:

> If it starts with %crosstool_top%/ or is any relative path, it is interpreted relative to the crosstool top.

This PR changes the includes paths to be prefixed with `%workspace%` so instead no prefix is added.

