### PR TITLE
Remove -fdebug-prefix-map for toolchain

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -118,7 +118,6 @@ def cc_toolchain_config(
         "-D__DATE__=\"redacted\"",
         "-D__TIMESTAMP__=\"redacted\"",
         "-D__TIME__=\"redacted\"",
-        "-fdebug-prefix-map={}=__bazel_toolchain_llvm_repo__/".format(toolchain_path_prefix),
     ]
 
     is_xcompile = not (exec_os == target_os and exec_arch == target_arch)


### PR DESCRIPTION
The relative paths to toolchain components in binaries does not affect
hermeticity. It's possible these affect debugging instead, in which case
remapping them requires users to add reverse maps in their debugger
config. Instead leaving the paths as is makes these "just work" if users
have an external/ symlink in the root of their repo (which is common for
compile_commands.json as well).
