### PR TITLE
cc_wrapper: make built artifacts more reproducible but specifying `-ffile-prefix-map`

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -113,11 +113,12 @@ def cc_toolchain_config(
     unfiltered_compile_flags = [
         # Do not resolve our symlinked resource prefixes to real paths.
         "-no-canonical-prefixes",
-        # Reproducibility
+        # Reproducibility.
         "-Wno-builtin-macro-redefined",
         "-D__DATE__=\"redacted\"",
         "-D__TIMESTAMP__=\"redacted\"",
         "-D__TIME__=\"redacted\"",
+        "-ffile-prefix-map=${{pwd}}=__bazel_toolchain_llvm_repo__",
     ]
 
     is_xcompile = not (exec_os == target_os and exec_arch == target_arch)
@@ -150,6 +151,8 @@ def cc_toolchain_config(
     link_flags = [
         "--target=" + target_system_name,
         "-no-canonical-prefixes",
+        # Reproducibility.
+        "-ffile-prefix-map=${{pwd}}=__bazel_toolchain_llvm_repo__",
     ]
 
     stdlib = compiler_configuration["stdlib"]

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -151,8 +151,6 @@ def cc_toolchain_config(
     link_flags = [
         "--target=" + target_system_name,
         "-no-canonical-prefixes",
-        # Reproducibility.
-        "-ffile-prefix-map=${{pwd}}=__bazel_toolchain_llvm_repo__",
     ]
 
     stdlib = compiler_configuration["stdlib"]

--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -34,12 +34,14 @@ set -euo pipefail
 
 if [[ -f %{toolchain_path_prefix}bin/clang ]]; then
   execroot_path=""
+  execroot_abs_path="${PWD}/"
 elif [[ ${BASH_SOURCE[0]} == "/"* ]]; then
   # Some consumers of `CcToolchainConfigInfo` (e.g. `cmake` from rules_foreign_cc)
   # change CWD and call $CC (this script) with its absolute path.
   # For cases like this, we'll try to find `clang` through an absolute path.
   # This script is at _execroot_/external/_repo_name_/bin/cc_wrapper.sh
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*}/"
+  execroot_abs_path="$(cd "${execroot_path}" && pwd -P)/"
 else
   echo >&2 "ERROR: could not find clang; PWD=\"${PWD}\"; PATH=\"${PATH}\"."
   exit 5
@@ -53,6 +55,9 @@ function sanitize_option() {
     # shellcheck disable=SC2206
     parts=(${opt/=/ }) # Split flag name and value into array.
     printf "%s" "${parts[0]}=${execroot_path}${parts[1]}"
+  elif [[ ${opt} == *"\${{pwd}}"* ]]; then
+    # Replace the literal string '${{pwd}}' with the execroot.
+    printf "%s" "${opt//\$\{\{pwd\}\}/${execroot_abs_path%/}}"
   else
     printf "%s" "${opt}"
   fi

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -79,6 +79,9 @@ function sanitize_option() {
     # shellcheck disable=SC2206
     parts=(${opt/=/ }) # Split flag name and value into array.
     printf "%s" "${parts[0]}=${execroot_path}${parts[1]}"
+  elif [[ ${opt} == *"\${{pwd}}"* ]]; then
+    # Replace the literal string '${{pwd}}' with the execroot.
+    printf "%s" "${opt//\$\{\{pwd\}\}/${execroot_abs_path%/}}"
   else
     printf "%s" "${opt}"
   fi


### PR DESCRIPTION
This PR aims to make artifacts built with `toolchains_llvm` more reproducible by specifying:
```
-ffile-prefix-map=${{pwd}}=__bazel_toolchain_llvm_repo__
```
in the compile and linker flags. Then in `cc_wrapper.sh` we replace `${{pwd}}` with the current absolute path the script is being invoked from. This should result in builds being more reproducible by replacing absolute local paths in the binary with `__bazel_toolchain_llvm_repo__`.

For example, today in the [MaterializeInc/materialize](https://github.com/MaterializeInc/materialize/) repo, building the `@bzip2//:bzip2` target and running `strings` on the final binary, I get several results like this:
```
/private/var/tmp/_bazel_parker.timmerman/497be8b2783f71dbb03155dd9130f54f/sandbox/darwin-sandbox/977/execroot/__main__
```
After this PR all said entries are replaced with:
```
__bazel_toolchain_llvm_repo__
```

@keith I see in #440 you removed the use of `-fdebug-prefix-path`, I'm curious what you think of this since it not only effects debug info but also pre-processor macros.