### PR TITLE
Emit canonical labels if needed in `pkg_name_from_label`

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -201,10 +201,8 @@ def is_absolute_path(val):
     return val and val[0] == "/" and (len(val) == 1 or val[1] != "/")
 
 def pkg_name_from_label(label):
-    if label.workspace_name:
-        return "@" + label.workspace_name + "//" + label.package
-    else:
-        return label.package
+    s = str(label)
+    return s[:s.rindex(":")]
 
 def pkg_path_from_label(label):
     if label.workspace_root:


### PR DESCRIPTION
Previously resulted in errors such as:
```
   Traceback (most recent call last):
	File "/private/var/tmp/_bazel_fmeum/5d22c23119063f77cfcdafc5f5d52f01/external/toolchains_llvm+/toolchain/internal/configure.bzl", line 141, column 66, in llvm_config_impl
		sysroot_paths_dict, sysroot_labels_dict = _sysroot_paths_dict(
	File "/private/var/tmp/_bazel_fmeum/5d22c23119063f77cfcdafc5f5d52f01/external/toolchains_llvm+/toolchain/internal/sysroot.bzl", line 76, column 53, in sysroot_paths_dict
		path = _canonical_dir_path(str(rctx.path(label).dirname))
Error in path: Unable to load package for @@[unknown repo 'toy-toolchain++toy_sysroot+sysroot_amd64_ubuntu' requested from @@toolchains_llvm+]//:BUILD.bazel: The repository '@@[unknown repo 'toy-toolchain++toy_sysroot+sysroot_amd64_ubuntu' requested from @@toolchains_llvm+]' could not be resolved: No repository visible as '@toy-toolchain++toy_sysroot+sysroot_amd64_ubuntu' from repository '@@toolchains_llvm+
```