### PR TITLE
Rules pycross fix

### DIFF
--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -34,7 +34,7 @@ set -euo pipefail
 
 if [[ -f %{toolchain_path_prefix}bin/clang ]]; then
   execroot_path=""
-elif [[ ${BASH_SOURCE[0]} == "/"* ]]; then
+elif [[ ${BASH_SOURCE[0]} == "/"* ]] || [[ ${BASH_SOURCE[0]} == "../"* ]]; then
   # Some consumers of `CcToolchainConfigInfo` (e.g. `cmake` from rules_foreign_cc)
   # change CWD and call $CC (this script) with its absolute path.
   # For cases like this, we'll try to find `clang` through an absolute path.

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -57,7 +57,7 @@ function parse_option() {
 if [[ -f %{toolchain_path_prefix}bin/clang ]]; then
   execroot_path=""
   execroot_abs_path="${PWD}/"
-elif [[ ${BASH_SOURCE[0]} == "/"* ]]; then
+elif [[ ${BASH_SOURCE[0]} == "/"* ]] || [[ ${BASH_SOURCE[0]} == "../"* ]]; then
   # Some consumers of `CcToolchainConfigInfo` (e.g. `cmake` from rules_foreign_cc)
   # change CWD and call $CC (this script) with its absolute path.
   # For cases like this, we'll try to find `clang` through an absolute path.


### PR DESCRIPTION
Using toolschains_llvm with rules_pycross results in this error. It is executing the script with a preceeding `../` and adding this case to the existing condition to the cc_wrapper fixes it.

```
ERROR: /private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/external/rules_pycross~~lock_file~pip/deps/BUILD.bazel:5:8: Building grpclib-0.4.7.tar.gz failed: (Exit 1): wheel_builder failed: error executing WheelBuild command (from target @@rules_pycross~~lock_file~pip//deps:_build_grpclib@0.4.7) bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder --sdist ... (remaining 27 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/sandbox/darwin-sandbox/737/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder.runfiles/_main/../rules_pycross~/pycross/private/tools/wheel_builder.py:394: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
  f.extractall(sdist_dir)
ERROR: could not find clang; PWD="/private/var/folders/2w/wc8_231n6dng2q_2yplq2cd00000gn/T/wheelbuild0yipqk0q/sdist"; PATH="/bin:/usr/bin:/usr/local/bin".
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/sandbox/darwin-sandbox/737/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder.runfiles/_main/../rules_pycross~/pycross/private/tools/wheel_builder.py", line 1033, in <module>
    main_wrapper(parse_flags())
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/sandbox/darwin-sandbox/737/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder.runfiles/_main/../rules_pycross~/pycross/private/tools/wheel_builder.py", line 1026, in main_wrapper
    main(args, _temp_dir, _is_debug)
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/sandbox/darwin-sandbox/737/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder.runfiles/_main/../rules_pycross~/pycross/private/tools/wheel_builder.py", line 802, in main
    wrapper_sysconfig_vars = generate_cc_wrappers(
                             ^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/sandbox/darwin-sandbox/737/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder.runfiles/_main/../rules_pycross~/pycross/private/tools/wheel_builder.py", line 319, in generate_cc_wrappers
    wrapped_cc = wrap_cc("cc", orig_cc, cflags, python_exe, bin_dir)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/sandbox/darwin-sandbox/737/execroot/_main/bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder.runfiles/_main/../rules_pycross~/pycross/private/tools/wheel_builder.py", line 270, in wrap_cc
    version_str = subprocess.check_output([cc_exe, "--version"]).decode("utf-8")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/execroot/_main/external/rules_python~~python~python_3_12_aarch64-apple-darwin/lib/python3.12/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/execroot/_main/external/rules_python~~python~python_3_12_aarch64-apple-darwin/lib/python3.12/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['../bazel-execroot/_main/external/toolchains_llvm~~llvm~llvm_toolchain/bin/cc_wrapper.sh', '--version']' returned non-zero exit status 5.
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /private/var/tmp/_bazel_julian.gautier/f0d3e1ae37dbfe8fdd0ee06626d02ae2/external/rules_pycross~~lock_file~pip/deps/BUILD.bazel:5:8 Installing grpclib-0.4.7.whl failed: (Exit 1): wheel_builder failed: error executing WheelBuild command (from target @@rules_pycross~~lock_file~pip//deps:_build_grpclib@0.4.7) bazel-out/darwin_arm64-opt-exec-ST-502cecfa30dd/bin/external/rules_pycross~/pycross/private/tools/wheel_builder --sdist ... (remaining 27 arguments skipped)
```