### PR TITLE
Make invocation of bash more Posix conformant.

### DIFF
--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Bazel Authors. All rights reserved.
 #

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #

--- a/utils/llvm_checksums.sh
+++ b/utils/llvm_checksums.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022 The Bazel Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Hard-coding the location of the shell to be in `/bin/bash` is not always working as not all Posix-conformant operating systems (such as NixOS) provide the path /bin/bash; so shell scripts won't be able to execute.

Instead, use the `/usr/bin/env bash` idiom to reliably find the shell to execute.

This fix is only applied to the critical scripts that might be executed on the users' machine; the *_test*sh scripts are left as-is.