### PR TITLE
Remove %workspace% before checking path

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -615,6 +615,7 @@ native_binary(
 
 def _is_hermetic_or_exists(rctx, path, sysroot_path):
     path = path.replace("%sysroot%", sysroot_path).replace("//", "/")
+    path = path.removeprefix("%workspace%")
     if not path.startswith("/"):
         return True
     return rctx.path(path).exists


### PR DESCRIPTION
The paths checked by `_is_hermetic_or_exists` may begin with "%workspace%" which prevents the check for the path existing. In that case, the system module map may contain include paths that don't exist. In turn that can cause warnings for any target using layering check (notably Abseil).