### PR TITLE
Silence "canonical reproducible form" warning from repo rule

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -231,6 +231,9 @@ def attr_dict(attr):
     for key in dir(attr):
         if not hasattr(attr, key):
             fail("key %s not found in attributes" % key)
+        if key[0] == "_":
+            # Don't update private attrs.
+            continue
         val = getattr(attr, key)
 
         # Make mutable copies of frozen types.


### PR DESCRIPTION
Prior to this fix, when using Bazel 8.1.1 then this kind of stanza in a MODULE file ...

```bzl
bazel_dep(name = "toolchains_llvm", version = "1.3.0")
llvm = use_repo_rule("@toolchains_llvm//toolchain:rules.bzl", "llvm")
llvm(
    name = "llvm",
    llvm_version = "19.1.3",
    ...
)
```

...  would generate this irrelevant suggestion ...

```
DEBUG: Rule '+_repo_rules4+llvm' indicated that a canonical reproducible form can be obtained by modifying arguments
  _action_listener = <unknown object com.google.devtools.build.lib.packages.Attribute$LabelListLateBoundDefault>,
  _config_dependencies = [],
  _configure = False,
  _environ = [],
  _original_name = "llvm"
DEBUG: Repository +_repo_rules4+llvm instantiated at:
  <builtin>: in <toplevel>
Repository rule llvm defined at:
  .../external/toolchains_llvm+/toolchain/rules.bzl:27:23: in <toplevel>
```

With this fix, the message no longer appears.