### PR TITLE
Add initial support for linux-armv7

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -31,6 +31,14 @@ platform(
 )
 
 platform(
+    name = "linux-armv7",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:armv7",
+    ],
+)
+
+platform(
     name = "darwin-x86_64",
     constraint_values = [
         "@platforms//os:osx",

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -81,6 +81,14 @@ def cc_toolchain_config(
             "clang",
             "glibc_unknown",
         ),
+        "linux-armv7": (
+            "clang-armv7-linux",
+            "armv7",
+            "glibc_unknown",
+            "clang",
+            "clang",
+            "glibc_unknown",
+        ),
         "linux-x86_64": (
             "clang-x86_64-linux",
             "k8",

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -15,6 +15,7 @@
 SUPPORTED_TARGETS = [
     ("linux", "x86_64"),
     ("linux", "aarch64"),
+    ("linux", "armv7"),
     ("darwin", "x86_64"),
     ("darwin", "aarch64"),
     ("none", "wasm32"),

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -321,6 +321,7 @@ def _cc_toolchain_str(
         "darwin-x86_64": "x86_64-apple-macosx",
         "darwin-aarch64": "aarch64-apple-macosx",
         "linux-aarch64": "aarch64-unknown-linux-gnu",
+        "linux-armv7": "armv7-unknown-linux-gnueabihf",
         "linux-x86_64": "x86_64-unknown-linux-gnu",
         "wasm32": "wasm32-unknown-unknown",
         "wasm64": "wasm64-unknown-unknown",


### PR DESCRIPTION
This change allows users to target `linux-armv7` without running into an explicit fail due to missing definitions.