### PR TITLE
Create sanitized response file instead of expanding arguments

### DIFF
--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -75,10 +75,11 @@ for ((i = 0; i <= $#; i++)); do
     tmpfile=$(mktemp)
     CLEANUP_FILES+=("${tmpfile}")
     while IFS= read -r opt; do
-      echo "$(
+      opt="$(
         set -e
         sanitize_option "${opt}"
-      )" >>"${tmpfile}"
+      )"
+      echo "${opt}" >>"${tmpfile}"
     done <"${!i:1}"
     cmd+=("@${tmpfile}")
   else

--- a/toolchain/cc_wrapper.sh.tpl
+++ b/toolchain/cc_wrapper.sh.tpl
@@ -69,7 +69,6 @@ function sanitize_option() {
 }
 
 cmd=()
-tmpfiles=()
 for ((i = 0; i <= $#; i++)); do
   if [[ ${!i} == @* && -r "${i:1}" ]]; then
     # Create a new, sanitized file.
@@ -79,8 +78,8 @@ for ((i = 0; i <= $#; i++)); do
       echo "$(
         set -e
         sanitize_option "${opt}"
-      )" >> "${tmpfile}"
-    done  <"${!i:1}"
+      )" >>"${tmpfile}"
+    done <"${!i:1}"
     cmd+=("@${tmpfile}")
   else
     opt="$(

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -100,12 +100,12 @@ for ((i = 0; i <= $#; i++)); do
     CLEANUP_FILES+=("${tmpfile}")
     while IFS= read -r opt; do
       if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
-        echo "-fuse-ld=lld" >> ${tmpfile}
+        echo "-fuse-ld=lld" >>${tmpfile}
       fi
       parse_option "$(
         set -e
         sanitize_option "${opt}"
-      )" >> ${tmpfile}
+      )" >>${tmpfile}
     done <"${!i:1}"
     cmd+=("@${tmpfile}")
   else

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -100,12 +100,13 @@ for ((i = 0; i <= $#; i++)); do
     CLEANUP_FILES+=("${tmpfile}")
     while IFS= read -r opt; do
       if [[ ${opt} == "-fuse-ld=ld64.lld" ]]; then
-        echo "-fuse-ld=lld" >>${tmpfile}
+        echo "-fuse-ld=lld" >>"${tmpfile}"
       fi
-      parse_option "$(
+      opt="$(
         set -e
         sanitize_option "${opt}"
-      )" >>${tmpfile}
+      )"
+      parse_option "${opt}" >>"${tmpfile}"
     done <"${!i:1}"
     cmd+=("@${tmpfile}")
   else


### PR DESCRIPTION
The cc_wrapper.sh scripts inspects response files and sanitizes each line within them.  How the logic is structured currently causes all of these arguments to the be directly used later in the script.  This can run into argument overflows.  It can also run into problems where quoting in response files and from args is treated differently.

This addresses some of the comments in #430, namely cleaning up files and not overwriting the input files.  I have not tried to apply a threshold here as that is best left up to the tooling that previously decided to use response files, which can cause difficult to debug changes in behavior.

This conflicts with #479, but is trying to address the same underlying problem of quoted arguments in response files as the result of golang's link actions.

Fixes #421