### PR TITLE
Tweaks

### DIFF
--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -55,27 +55,27 @@ _toolchain_tools_darwin = {
 }
 
 def exec_os_key(rctx):
-    (os, version, arch) = os_version_arch(rctx)
+    (os, version, arch) = dist_version_arch(rctx)
     if version == "":
         return "%s-%s" % (os, arch)
     else:
         return "%s-%s-%s" % (os, version, arch)
 
 _known_distros = [
-    "freebsd",
-    "suse",
-    "ubuntu",
+    "almalinux",
+    "amzn",
     "arch",
-    "manjaro",
+    "centos",
     "debian",
     "fedora",
-    "centos",
-    "amzn",
-    "raspbian",
-    "pop",
-    "rhel",
+    "freebsd",
+    "manjaro",
     "ol",
-    "almalinux",
+    "pop",
+    "raspbian",
+    "rhel",
+    "suse",
+    "ubuntu",
 ]
 
 def _linux_dist(rctx):
@@ -102,7 +102,7 @@ def _linux_dist(rctx):
 
     return distname, version
 
-def os_version_arch(rctx):
+def dist_version_arch(rctx):
     _os = os(rctx)
     _arch = arch(rctx)
 

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -62,7 +62,7 @@ def exec_os_key(rctx):
         return "%s-%s-%s" % (os, version, arch)
 
 _known_distros = [
-    # keep sorted 
+    # keep sorted
     "almalinux",
     "amzn",
     "arch",

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -62,6 +62,7 @@ def exec_os_key(rctx):
         return "%s-%s-%s" % (os, version, arch)
 
 _known_distros = [
+    # keep sorted 
     "almalinux",
     "amzn",
     "arch",

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -751,7 +751,7 @@ def _distribution_urls(rctx):
     strip_prefix = ""
     for suffix in [".exe", ".tar.gz", ".tar.xz", ".tar.zst"]:
         if basename.endswith(suffix):
-            strip_prefix = basename.rstrip(suffix)
+            strip_prefix = basename.removesuffix(suffix)
             break
     if not strip_prefix:
         fail("Unknown URL file extension {url}", url = basename)

--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -1,8 +1,8 @@
 load(
     "//toolchain/internal:common.bzl",
     _arch = "arch",
-    _os = "os",
     _dist_version_arch = "dist_version_arch",
+    _os = "os",
 )
 
 def _major_llvm_version(llvm_version):

--- a/toolchain/internal/release_name.bzl
+++ b/toolchain/internal/release_name.bzl
@@ -2,7 +2,7 @@ load(
     "//toolchain/internal:common.bzl",
     _arch = "arch",
     _os = "os",
-    _os_version_arch = "os_version_arch",
+    _dist_version_arch = "dist_version_arch",
 )
 
 def _major_llvm_version(llvm_version):
@@ -140,6 +140,18 @@ def _rhel_osname(arch, version, major_llvm_version, llvm_version):
 
     return None
 
+def _resolve_version_for_suse(major_llvm_version, llvm_version):
+    minor_llvm_version = _minor_llvm_version(llvm_version)
+    if major_llvm_version < 10:
+        os_name = "linux-sles11.3"
+    elif major_llvm_version == 10 and minor_llvm_version == 0:
+        os_name = "linux-sles11.3"
+    elif major_llvm_version < 13 or (major_llvm_version == 14 and minor_llvm_version == 0):
+        os_name = "linux-sles12.4"
+    else:
+        os_name = _ubuntu_osname("x86_64", "20.04", major_llvm_version, llvm_version)
+    return os_name
+
 def _linux(llvm_version, distname, version, arch):
     major_llvm_version = _major_llvm_version(llvm_version)
 
@@ -199,18 +211,6 @@ def _linux(llvm_version, distname, version, arch):
         os_name = os_name,
     )
 
-def _resolve_version_for_suse(major_llvm_version, llvm_version):
-    minor_llvm_version = _minor_llvm_version(llvm_version)
-    if major_llvm_version < 10:
-        os_name = "linux-sles11.3"
-    elif major_llvm_version == 10 and minor_llvm_version == 0:
-        os_name = "linux-sles11.3"
-    elif major_llvm_version < 13 or (major_llvm_version == 14 and minor_llvm_version == 0):
-        os_name = "linux-sles12.4"
-    else:
-        os_name = _ubuntu_osname("x86_64", "20.04", major_llvm_version, llvm_version)
-    return os_name
-
 def llvm_release_name_19(llvm_version, rctx_arch, rctx_os):
     arch = {
         "aarch64": "ARM64",
@@ -236,7 +236,7 @@ def llvm_release_name(rctx, llvm_version):
     if major_llvm_version >= 19:
         return llvm_release_name_19(llvm_version, _arch(rctx), _os(rctx))
     else:
-        (os, version, arch) = _os_version_arch(rctx)
+        (os, version, arch) = _dist_version_arch(rctx)
         if os == "darwin":
             return _darwin(llvm_version, arch)
         elif os == "windows":


### PR DESCRIPTION
Tweaks:
* Sort known distro names.
* Function `_os_version_arch` returns a dist(ribution) name and not an os name, so we rename it `_dist_version_arch`.
* Move `_resolve_version_for_suse` above `_linux` to follow order of the other helpers.
* Improve strip_prefix detection (also added `.exe` as we predict it, though we cannot really handle it (yet)).