### PR TITLE
Expand glob of toolchain /lib and /include

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -18,8 +18,8 @@ package(default_visibility = ["//visibility:public"])
 exports_files(glob(
     [
         "bin/*",
-        "lib/*",
-        "include/*",
+        "lib/**",
+        "include/**",
         "share/clang/*",
     ],
     allow_empty = True,


### PR DESCRIPTION
Some consumers might want files in subdirectories (e.g. libclang).