### PR TITLE
Add extra_llvm_distributions attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,25 @@ We currently offer limited customizability through attributes of the
 [llvm_toolchain\_\* rules](toolchain/rules.bzl). You can send us a PR to add
 more configuration attributes.
 
-The following shows how to add a specific version for a specific target before
-the version was added to [llvm_distributions.bzl](toolchain/internal/llvm_distributions.bzl):
+The `MODULE.bazel` example below demonstrates how to add new LLVM distributions before the toolchain has
+been updated. They can easily be computed using the provided checksum tool (see `llvm_checksums.sh -h`).
+
+```starlark
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
+llvm.toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "20.1.4",
+    llvm_distributions = {
+        "LLVM-20.1.4-Linux-ARM64.tar.xz": "4de80a332eecb06bf55097fd3280e1c69ed80f222e5bdd556221a6ceee02721a",
+        "LLVM-20.1.4-Linux-X64.tar.xz": "113b54c397adb2039fa45e38dc8107b9ec5a0baead3a3bac8ccfbb65b2340caa",
+        "LLVM-20.1.4-macOS-ARM64.tar.xz": "debb43b7b364c5cf864260d84ba1b201d49b6460fe84b76eaa65688dfadf19d2",
+        "clang+llvm-20.1.4-x86_64-pc-windows-msvc.tar.xz": "2b12ac1a0689e29a38a7c98c409cbfa83f390aea30c60b7a06e4ed73f82d2457",
+    },
+)
+```
+
+The following `WORKSPACE` snippet shows how to add a specific version for a specific target before
+the version was added to [llvm_distributions.bzl](toolchain/internal/llvm_distributions.bzl).
 
 ```starlark
 llvm_toolchain(

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", 
 llvm.toolchain(
     name = "llvm_toolchain",
     llvm_version = "20.1.4",
-    llvm_distributions = {
+    extra_llvm_distributions = {
         "LLVM-20.1.4-Linux-ARM64.tar.xz": "4de80a332eecb06bf55097fd3280e1c69ed80f222e5bdd556221a6ceee02721a",
         "LLVM-20.1.4-Linux-X64.tar.xz": "113b54c397adb2039fa45e38dc8107b9ec5a0baead3a3bac8ccfbb65b2340caa",
         "LLVM-20.1.4-macOS-ARM64.tar.xz": "debb43b7b364c5cf864260d84ba1b201d49b6460fe84b76eaa65688dfadf19d2",

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -739,8 +739,8 @@ def _get_llvm_version(rctx):
     return llvm_version
 
 def _get_all_llvm_distributions(rctx):
-    if rctx.attr.llvm_distributions:
-        return _llvm_distributions | rctx.attr.llvm_distributions
+    if rctx.attr.extra_llvm_distributions:
+        return _llvm_distributions | rctx.attr.extra_llvm_distributions
     return _llvm_distributions
 
 _UBUNTU_NAMES = [

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -52,6 +52,13 @@ llvm_repo_attrs.update({
                "`auto` value for the `distribution` attribute, and as a default value " +
                "for the `llvm_versions` attribute."),
     ),
+    "llvm_distributions": attr.string_dict(
+        mandatory = False,
+        doc = ("A dictionary that maps distributions to their SHA256 values. " +
+               "It allows for simple additon of llvm distributiosn using the " +
+               "'utils/lvm_checksums.sh' tool. This also allows to use the " +
+               "distributions lists of future toolchain versions."),
+    ),
     "urls": attr.string_list_dict(
         mandatory = False,
         doc = ("URLs to LLVM pre-built binary distribution archives, keyed by host OS " +

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -52,7 +52,7 @@ llvm_repo_attrs.update({
                "`auto` value for the `distribution` attribute, and as a default value " +
                "for the `llvm_versions` attribute."),
     ),
-    "llvm_distributions": attr.string_dict(
+    "extra_llvm_distributions": attr.string_dict(
         mandatory = False,
         doc = ("A dictionary that maps distributions to their SHA256 values. " +
                "It allows for simple additon of llvm distributiosn using the " +


### PR DESCRIPTION
This simplifies adding new versions without upgrading the toolchain.

Tested:
* Removed 20.1.4 and added those instead to the config of a repo using the toolchain.
* Added the config for 20.1.4 back to see whether the config can be present in the toolchain and in the user repo.