### PR TITLE
toolchain config: use "-l:libc++.a" and "-l:libc++abi.a" in sysroot

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -289,8 +289,8 @@ def cc_toolchain_config(
         ]
 
         link_flags.extend([
-            "-l:c++.a",
-            "-l:c++abi.a",
+            "-l:libc++.a",
+            "-l:libc++abi.a",
         ])
     elif stdlib == "dynamic-stdc++":
         cxx_flags = [


### PR DESCRIPTION
When cross compiling with a sysroot, the toolchain defaults to libstdc++.
However, if a user specifically selects libc++ like so:

```
   stdlib = {
       "linux-aarch64": "libc++",
       "linux-x86_64": "libc++",
    },

```

... we emit invalid linker flags. For all sysroots I could find, the name of the archive is "libc++.a" and "libc++abi.a", not "c++.a".