### PR TITLE
Add support for x86_64-unknown-none targets

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -23,6 +23,14 @@ platform(
 )
 
 platform(
+    name = "none-x86_64",
+    constraint_values = [
+        "@platforms//os:none",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
     name = "linux-aarch64",
     constraint_values = [
         "@platforms//os:linux",

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -97,6 +97,14 @@ def cc_toolchain_config(
             "clang",
             "glibc_unknown",
         ),
+        "none-x86_64": (
+            "clang-x86_64-none",
+            "k8",
+            "unknown",
+            "clang",
+            "unknown",
+            "unknown",
+        ),
         "wasm32": (
             "clang-wasm32",
             "wasm32",

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -20,8 +20,14 @@ SUPPORTED_TARGETS = [
     ("darwin", "aarch64"),
     ("none", "wasm32"),
     ("none", "wasm64"),
+    ("none", "x86_64"),
     ("wasip1", "wasm32"),
     ("wasip1", "wasm64"),
+]
+
+# These are targets that can build without a sysroot.
+SUPPORTED_NO_SYSROOT_TARGETS = [
+    ("none", "x86_64"),
 ]
 
 # Map of tool name to its symlinked name in the tools directory.
@@ -126,7 +132,7 @@ def os(rctx):
 
     name = rctx.attr.exec_os
     if name:
-        if name in ("linux", "darwin"):
+        if name in ("linux", "darwin", "none"):
             return name
         else:
             fail("Unsupported value for exec_os: %s" % name)

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -33,6 +33,7 @@ load(
     _os_bzl = "os_bzl",
     _os_from_rctx = "os_from_rctx",
     _pkg_path_from_label = "pkg_path_from_label",
+    _supported_no_sysroot_targets = "SUPPORTED_NO_SYSROOT_TARGETS",
     _supported_targets = "SUPPORTED_TARGETS",
     _toolchain_tools = "toolchain_tools",
 )
@@ -300,9 +301,11 @@ def _cc_toolchain_str(
         if exec_os == target_os and exec_arch == target_arch:
             # For darwin -> darwin, we can use the macOS SDK path.
             sysroot_path = _default_sysroot_path(rctx, exec_os)
+        elif target_pair in _supported_no_sysroot_targets:
+            sysroot_path = ""
         else:
             # We are trying to cross-compile without a sysroot, let's bail.
-            # TODO: Are there situations where we can continue?
+            # TODO: Are there other situations where we can continue?
             return ""
 
     extra_files_str = "\":internal-use-files\""
@@ -323,6 +326,7 @@ def _cc_toolchain_str(
         "linux-aarch64": "aarch64-unknown-linux-gnu",
         "linux-armv7": "armv7-unknown-linux-gnueabihf",
         "linux-x86_64": "x86_64-unknown-linux-gnu",
+        "none-x86_64": "x86_64-unknown-none",
         "wasm32": "wasm32-unknown-unknown",
         "wasm64": "wasm64-unknown-unknown",
         "wasip1-wasm32": "wasm32-wasip1",


### PR DESCRIPTION
By default, no sysroot is used.

This is useful for bare-metal targets, firmwares, etc.

We are actively using this patch in https://github.com/project-oak/oak