### PR TITLE
Make `wasm-ld` optional

### DIFF
--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -38,12 +38,11 @@ filegroup(
 
 filegroup(
     name = "ld",
+    # Not all distributions contain wasm-ld.
     srcs = [
         "bin/ld.lld",
         "bin/ld64.lld",
-        # Not all distributions contain wasm-ld.
-        glob(["bin/wasm-ld"], allow_empty = True),
-    ],
+    ] + glob(["bin/wasm-ld"], allow_empty = True),
 )
 
 filegroup(

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -41,7 +41,8 @@ filegroup(
     srcs = [
         "bin/ld.lld",
         "bin/ld64.lld",
-        "bin/wasm-ld",
+        # Not all distributions contain wasm-ld.
+        glob(["bin/wasm-ld"], allow_empty = True),
     ],
 )
 


### PR DESCRIPTION
May not be contained in all distributions.