### PR TITLE
Mark downloaded repository as reproducible

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -86,7 +86,12 @@ if [[ -z ${toolchain_name} && -z ${disable_wasm_tests} ]]; then
   "${bazel}" clean --expunge
   # Remove the repo contents cache in addition to cleaning the work trees since
   # this is where the llvm toolchains are stored.
-  rm -r "$HOME/.cache/bazel/_bazel_$USER/cache/repos/v1/contents"
+  user="$(id -un)"
+  if [[ ${OSTYPE} == 'darwin'* ]]; then
+    rm -rf "/private/var/tmp/_bazel_${user}/cache/repos/v1/contents"
+  else
+    rm -rf "${HOME}/.cache/bazel/_bazel_${user}/cache/repos/v1/contents"
+  fi
   "${bazel}" ${TEST_MIGRATION:+"--strict"} --bazelrc=/dev/null test \
     "${common_test_args[@]}" "${test_args[@]}" "${wasm_targets[@]}"
 fi

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -84,6 +84,9 @@ if [[ -z ${toolchain_name} && -z ${disable_wasm_tests} ]]; then
     "//wasm:all"
   )
   "${bazel}" clean --expunge
+  # Remove the repo contents cache in addition to cleaning the work trees since
+  # this is where the llvm toolchains are stored.
+  rm -r "$HOME/.cache/bazel/_bazel_$USER/cache/repos/v1/contents"
   "${bazel}" ${TEST_MIGRATION:+"--strict"} --bazelrc=/dev/null test \
     "${common_test_args[@]}" "${test_args[@]}" "${wasm_targets[@]}"
 fi

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 load(
     "//toolchain/internal:common.bzl",
+    _attr_dict = "attr_dict",
     _os = "os",
     _supported_os_arch_keys = "supported_os_arch_keys",
 )

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -334,4 +334,10 @@ def llvm_repo_impl(rctx):
     # do want to make changes, then we should do it through a patch file, and
     # document it for users of toolchain_roots attribute.
 
-    return updated_attrs
+    if hasattr(rctx, "repo_metadata"):
+        if updated_attrs == _attr_dict(rctx.attr):
+            return rctx.repo_metadata(reproducible = True)
+        else:
+            return rctx.repo_metadata(attrs_for_reproducibility = updated_attrs)
+    else:
+        return updated_attrs


### PR DESCRIPTION
#515 only makes the config repository reproducible. The downloaded toolchains are store in a separate repository. Since this separate repository is not marked as reproducible, the extracted files are currently not cached.

This change fixes that by marking the repositority that contains the downloaded toolchain also reproducible.

Similar to the git repo rule here: https://github.com/bazelbuild/bazel/blob/648f991bd8653408ba6b4c24c6ff8fa4fce51eba/tools/build_defs/repo/git.bzl#L219