### PR TITLE
Use debian bookworm

### DIFF
--- a/tests/scripts/debian_test.sh
+++ b/tests/scripts/debian_test.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 images=(
-  "debian:latest"
+  "debian:bookworm"
 )
 
 git_root=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
In debian:latest (As of August 9th 2025 that is 13 aka "Trixie") there is no simple way of getting libtinfo5 immediately. So as a quick way to moving forward we stick to debian:bookworm insteam.

This allows us to proceed with https://github.com/bazel-contrib/toolchains_llvm/pull/539.

After that we should possibly have separate tests for debian:bookworm and debian:trixie.