### PR TITLE
Don't forbid use_extension("llvm.bzl") inside non-root modules

### DIFF
--- a/toolchain/extensions/llvm.bzl
+++ b/toolchain/extensions/llvm.bzl
@@ -50,10 +50,10 @@ def _constraint_dict(tags, name):
 
 def _llvm_impl_(module_ctx):
     for mod in module_ctx.modules:
-        if not mod.is_root:
-            fail("Only the root module can use the 'llvm' extension")
         toolchain_names = []
         for toolchain_attr in mod.tags.toolchain:
+            if not mod.is_root:
+                fail("Only the root module can use the 'llvm.toolchain()' tag")
             name = toolchain_attr.name
             toolchain_names.append(name)
             attrs = {


### PR DESCRIPTION
Though I understand why the authors of this module don't want to permit module extension tag declarations of llvm.toolchain() in non-root modules, not being able to depend on the extension entirely is fairly restrictive.

In one of my Bazel projects I want to be able to use clang-format as part of some reformatting script. These scripts are not just used by the module itself, but also by some other modules that depend on it. I therefore have the following stanza in MODULE.bazel:

    llvm_dev = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
    llvm_dev.toolchain(
        llvm_version = "17.0.6",
    )
    llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
    use_repo(llvm, "llvm_toolchain_llvm")

I can then use label @llvm_toolchain_llvm//:bin/clang-format to get a copy of clang-format. The current logic prevents me from doing this, because the second use_extension() call is rejected outright, even if it doesn't invoke llvm.toolchain().