### PR TITLE
Update llvm version used for tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
           USE_BZLMOD: ${{ matrix.bzlmod }}
-        run: tests/scripts/run_tests.sh
+        run: tests/scripts/run_tests.sh -O
   toolchain_test:
     strategy:
       fail-fast: false
@@ -98,7 +98,7 @@ jobs:
       - name: Test
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
-        run: tests/scripts/${{ matrix.script }}_test.sh
+        run: tests/scripts/${{ matrix.script }}_test.sh ${{ matrix.script == 'ubuntu_20_04' && '' || '-O' }}
   xcompile_test:
     strategy:
       fail-fast: false
@@ -123,7 +123,7 @@ jobs:
       - name: Test
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
-        run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_absolute_paths//:cc-toolchain-x86_64-linux
+        run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_absolute_paths//:cc-toolchain-x86_64-linux -O
   sys_paths_test:
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Test
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
-        run: tests/scripts/${{ matrix.script }}_test.sh ${{ matrix.script == 'ubuntu_20_04' && '' || '-O' }}
+        run: tests/scripts/${{ matrix.script }}_test.sh
   xcompile_test:
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v5
       - run: tests/scripts/ubuntu_install_libtinfo.sh
       - name: Download and Extract LLVM distribution
-        # The downloaded version here must match the llvm_version for llvm_toolchain_with_system_llvm in tests/{MODULE.bazel,WORKSPACE}
+        # The downloaded version here must match version specified as '-v' arg to run_tests.sh below.
         env:
           release: llvmorg-16.0.0
           archive: clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04
@@ -144,4 +144,4 @@ jobs:
       - name: Test
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
-        run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux
+        run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux -v 16.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
       - uses: actions/checkout@v5
       - run: tests/scripts/ubuntu_install_libtinfo.sh
       - name: Download and Extract LLVM distribution
+        # The downloaded version here must match the llvm_version for llvm_toolchain_with_system_llvm in tests/{MODULE.bazel,WORKSPACE}
         env:
           release: llvmorg-16.0.0
           archive: clang+llvm-16.0.0-x86_64-linux-gnu-ubuntu-18.04

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.38.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
-bazel_dep(name = "rules_cc", version = "0.2.13")
+bazel_dep(name = "rules_cc", version = "0.2.8")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "helly25_bzl", version = "0.3.1")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,10 +20,10 @@ module(
 )
 
 bazel_dep(name = "bazel_features", version = "1.38.0")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "aspect_bazel_lib", version = "2.0.0")
-bazel_dep(name = "rules_cc", version = "0.2.2")
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
+bazel_dep(name = "rules_cc", version = "0.2.13")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "helly25_bzl", version = "0.3.1")
 
 bazel_dep(name = "tar.bzl", version = "0.6.0")

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -81,7 +81,7 @@ build_test(
 dwp_file(
     name = "stdlib.dwp",
     src = ":stdlib_bin",
-    # NOTE: we should eventually we able to drop this; see #109.
+    # NOTE: we should eventually be able to drop this; see #109.
     override_compilation_mode = "dbg",
     target_compatible_with = [
         "@platforms//os:linux",
@@ -95,13 +95,27 @@ build_test(
     ],
 )
 
+# Define a constraint setting and value for OpenMP testing.
+# Use: bazel ... --define omp=toolchain_16
+# The value is provided automatically by the run_tests.sh script and defaults to
+# the standard llvm_toolchain'. The script removes the '@' and any target.
+constraint_setting(name = "omp")
+
+constraint_value(
+    name = "llvm_toolchain_16",
+    constraint_setting = "omp",
+)
+
 # Simple test in C that depends on libomp.
 cc_test(
     name = "omp_test",
     srcs = ["omp_test.c"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
-    deps = ["@llvm_toolchain//:omp"],
+    deps = select({
+        ":llvm_toolchain_16": ["@llvm_toolchain_16//:omp"],
+        "//conditions:default": ["@llvm_toolchain//:omp"],
+    }),
 )
 
 # C++ variant of omp_test; needed to check that including the llvm toolchain
@@ -114,7 +128,10 @@ cc_test(
     srcs = ["omp_test.cc"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
-    deps = ["@llvm_toolchain//:omp"],
+    deps = select({
+        ":llvm_toolchain_16": ["@llvm_toolchain_16//:omp"],
+        "//conditions:default": ["@llvm_toolchain//:omp"],
+    }),
 )
 
 sh_test(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -101,6 +101,7 @@ cc_test(
     srcs = ["omp_test.c"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
+    tags = ["manual"],
     deps = ["@llvm_toolchain//:omp"],
 )
 
@@ -114,6 +115,7 @@ cc_test(
     srcs = ["omp_test.cc"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
+    tags = ["manual"],
     deps = ["@llvm_toolchain//:omp"],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -101,7 +101,6 @@ cc_test(
     srcs = ["omp_test.c"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
-    tags = ["manual"],
     deps = ["@llvm_toolchain//:omp"],
 )
 
@@ -115,7 +114,6 @@ cc_test(
     srcs = ["omp_test.cc"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
-    tags = ["manual"],
     deps = ["@llvm_toolchain//:omp"],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -95,29 +95,13 @@ build_test(
     ],
 )
 
-# Define a constraint setting and value for OpenMP testing.
-# Use: bazel ... --define omp=toolchain_16
-# The value is provided automatically by the run_tests.sh script and defaults to
-# the standard llvm_toolchain'. The script removes the '@' and any target.
-constraint_setting(name = "omp")
-
-constraint_value(
-    name = "llvm_toolchain_15",
-    constraint_setting = "omp",
-    visibility = ["//visibility:public"],
-)
-
 # Simple test in C that depends on libomp.
 cc_test(
     name = "omp_test",
     srcs = ["omp_test.c"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
-    deps = select({
-        ":llvm_toolchain_15": ["@llvm_toolchain_15//:omp"],
-        #":llvm_toolchain_with_sysroot": ["@llvm_toolchain_with_sysroot//:omp"],
-        "//conditions:default": ["@llvm_toolchain//:omp"],
-    }),
+    deps = ["@llvm_toolchain//:omp"],
 )
 
 # C++ variant of omp_test; needed to check that including the llvm toolchain
@@ -130,11 +114,7 @@ cc_test(
     srcs = ["omp_test.cc"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
-    deps = select({
-        ":llvm_toolchain_15": ["@llvm_toolchain_15//:omp"],
-        #":llvm_toolchain_with_sysroot": ["@llvm_toolchain_with_sysroot//:omp"],
-        "//conditions:default": ["@llvm_toolchain//:omp"],
-    }),
+    deps = ["@llvm_toolchain//:omp"],
 )
 
 sh_test(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -101,6 +101,7 @@ cc_test(
     srcs = ["omp_test.c"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
+    tags = ["manual"],
     deps = ["@llvm_toolchain//:omp"],
 )
 
@@ -114,7 +115,16 @@ cc_test(
     srcs = ["omp_test.cc"],
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
+    tags = ["manual"],
     deps = ["@llvm_toolchain//:omp"],
+)
+
+test_suite(
+    name = "omp_tests",
+    tests = [
+        ":omp_test",
+        ":omp_test_cc",
+    ],
 )
 
 sh_test(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -102,8 +102,9 @@ build_test(
 constraint_setting(name = "omp")
 
 constraint_value(
-    name = "llvm_toolchain_16",
+    name = "llvm_toolchain_15",
     constraint_setting = "omp",
+    visibility = ["//visibility:public"],
 )
 
 # Simple test in C that depends on libomp.
@@ -113,7 +114,8 @@ cc_test(
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
     deps = select({
-        ":llvm_toolchain_16": ["@llvm_toolchain_16//:omp"],
+        ":llvm_toolchain_15": ["@llvm_toolchain_15//:omp"],
+        #":llvm_toolchain_with_sysroot": ["@llvm_toolchain_with_sysroot//:omp"],
         "//conditions:default": ["@llvm_toolchain//:omp"],
     }),
 )
@@ -129,7 +131,8 @@ cc_test(
     copts = ["-fopenmp"],
     linkopts = ["-fopenmp"],
     deps = select({
-        ":llvm_toolchain_16": ["@llvm_toolchain_16//:omp"],
+        ":llvm_toolchain_15": ["@llvm_toolchain_15//:omp"],
+        #":llvm_toolchain_with_sysroot": ["@llvm_toolchain_with_sysroot//:omp"],
         "//conditions:default": ["@llvm_toolchain//:omp"],
     }),
 )

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -121,6 +121,7 @@ cc_test(
 
 test_suite(
     name = "omp_tests",
+    tags = ["manual"],
     tests = [
         ":omp_test",
         ":omp_test_cc",

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -73,7 +73,7 @@ LLVM_VERSIONS = {
 # Some tests do not yet work with LLVM versions > 16, so we define a separate
 # version set.
 LLVM_VERSIONS_15 = {
-    "": "latest:>15.0.0,<16",
+    "": "latest:>15.0.0,<17",
     "darwin-x86_64": "15.0.7",  # Verify this works as opposed to using one version.
 }
 

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -65,8 +65,9 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # through the `llvm_toolchain_with_sysroot` toolchain.
 # We use C++17 and the first LLVM version with full suppor is 16.0.0.
 # We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
+# MacOS X86 does not exist for LLVM 17 or 18, so we allow 19 as well.
 LLVM_VERSIONS = {
-    "": "first:>=17.0.0,<18",
+    "": "first:>=17.0.0,<20",
 }
 
 llvm.toolchain(

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -63,11 +63,19 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # When updating this version, also update the versions associated with
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
-# We use C++17 and the first LLVM version with full suppor is 16.0.0.
+# We use C++17 and the first LLVM version with full support is 16.0.0.
 # We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
 # MacOS X86 does not exist for LLVM 17 or 18, so we allow 19 as well.
 LLVM_VERSIONS = {
     "": "first:>=17.0.0,<20",
+}
+
+# Some tests do not yet work with LLVM versions > 16, so we define a separate
+# version set.
+LLVM_VERSIONS_16 = {
+    "": "16.0.0",
+    "darwin-aarch64": "16.0.5",
+    "darwin-x86_64": "15.0.7",
 }
 
 llvm.toolchain(
@@ -82,6 +90,20 @@ llvm.extra_target_compatible_with(
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 
 register_toolchains("@llvm_toolchain//:all")
+
+llvm.toolchain(
+    name = "llvm_toolchain_16",
+    cxx_standard = {"": "c++17"},
+    llvm_versions = LLVM_VERSIONS_16,
+)
+llvm.extra_target_compatible_with(
+    name = "llvm_toolchain_16",
+    constraints = ["@//:cxx17"],
+)
+use_repo(llvm, "llvm_toolchain_16")
+
+register_toolchains("@llvm_toolchain_16//:all")
+
 
 llvm.toolchain(
     name = "llvm_toolchain_cxx20",
@@ -150,7 +172,7 @@ use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 # Toolchain example with system LLVM; tested in GitHub CI.
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS,
+    llvm_versions = LLVM_VERSIONS_16,
 )
 
 # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
@@ -163,7 +185,7 @@ use_repo(llvm, "llvm_toolchain_with_system_llvm")
 # Toolchain example with a sysroot.
 llvm.toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = LLVM_VERSIONS,
+    llvm_versions = LLVM_VERSIONS_16,
 )
 
 # We can share the downloaded LLVM distribution with the first configuration.

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -22,7 +22,7 @@ local_path_override(
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_cc", version = "0.2.13")
+bazel_dep(name = "rules_cc", version = "0.2.8")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_rust", version = "0.67.0")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.0")

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -150,9 +150,10 @@ llvm.toolchain_root(
 use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 
 # Toolchain example with system LLVM; tested in GitHub CI.
+# The llvm_version must match the version specified in .github/workflows/tests.yml: sys_paths_test
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS,
+    llvm_versions = "16.0.0", 
 )
 
 # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -22,7 +22,7 @@ local_path_override(
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.2.8")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_rust", version = "0.67.0")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
@@ -72,10 +72,9 @@ LLVM_VERSIONS = {
 
 # Some tests do not yet work with LLVM versions > 16, so we define a separate
 # version set.
-LLVM_VERSIONS_16 = {
-    "": "16.0.0",
-    "darwin-aarch64": "16.0.5",
-    "darwin-x86_64": "15.0.7",
+LLVM_VERSIONS_15 = {
+    "": "latest:>15.0.0,<16",
+    "darwin-x86_64": "15.0.7",  # Verify this works as opposed to using one version.
 }
 
 llvm.toolchain(
@@ -92,17 +91,20 @@ use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 register_toolchains("@llvm_toolchain//:all")
 
 llvm.toolchain(
-    name = "llvm_toolchain_16",
+    name = "llvm_toolchain_15",
     cxx_standard = {"": "c++17"},
-    llvm_versions = LLVM_VERSIONS_16,
+    llvm_versions = LLVM_VERSIONS_15,
 )
 llvm.extra_target_compatible_with(
-    name = "llvm_toolchain_16",
-    constraints = ["@//:cxx17"],
+    name = "llvm_toolchain_15",
+    constraints = [
+        "@//:cxx17",
+        "//:llvm_toolchain_15",
+    ],
 )
-use_repo(llvm, "llvm_toolchain_16")
+use_repo(llvm, "llvm_toolchain_15")
 
-register_toolchains("@llvm_toolchain_16//:all")
+register_toolchains("@llvm_toolchain_15//:all")
 
 
 llvm.toolchain(
@@ -172,7 +174,7 @@ use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 # Toolchain example with system LLVM; tested in GitHub CI.
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS_16,
+    llvm_versions = LLVM_VERSIONS_15,
 )
 
 # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
@@ -185,7 +187,7 @@ use_repo(llvm, "llvm_toolchain_with_system_llvm")
 # Toolchain example with a sysroot.
 llvm.toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = LLVM_VERSIONS_16,
+    llvm_versions = LLVM_VERSIONS_15,
 )
 
 # We can share the downloaded LLVM distribution with the first configuration.

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -22,7 +22,7 @@ local_path_override(
 
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "rules_cc", version = "0.2.13")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_rust", version = "0.67.0")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.0")
@@ -66,14 +66,9 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # We use C++17 and the first LLVM version with full support is 16.0.0.
 # We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
 # MacOS X86 does not exist for LLVM 17 or 18, so we allow 19 as well.
+# We also allow to override this with a environment LLVM_VERSION for testing.
 LLVM_VERSIONS = {
-    "": "first:>=17.0.0,<20",
-}
-
-# Some tests do not yet work with LLVM versions > 16, so we define a separate
-# version set.
-LLVM_VERSIONS_15 = {
-    "": "latest:>15.0.0,<17",
+    "": "getenv(LLVM_VERSION,latest:>=17.0.0,<20)",
     "darwin-x86_64": "15.0.7",  # Verify this works as opposed to using one version.
 }
 
@@ -89,23 +84,6 @@ llvm.extra_target_compatible_with(
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 
 register_toolchains("@llvm_toolchain//:all")
-
-llvm.toolchain(
-    name = "llvm_toolchain_15",
-    cxx_standard = {"": "c++17"},
-    llvm_versions = LLVM_VERSIONS_15,
-)
-llvm.extra_target_compatible_with(
-    name = "llvm_toolchain_15",
-    constraints = [
-        "@//:cxx17",
-        "//:llvm_toolchain_15",
-    ],
-)
-use_repo(llvm, "llvm_toolchain_15")
-
-register_toolchains("@llvm_toolchain_15//:all")
-
 
 llvm.toolchain(
     name = "llvm_toolchain_cxx20",
@@ -174,7 +152,7 @@ use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 # Toolchain example with system LLVM; tested in GitHub CI.
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS_15,
+    llvm_versions = LLVM_VERSIONS,
 )
 
 # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
@@ -187,7 +165,7 @@ use_repo(llvm, "llvm_toolchain_with_system_llvm")
 # Toolchain example with a sysroot.
 llvm.toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = LLVM_VERSIONS_15,
+    llvm_versions = LLVM_VERSIONS,
 )
 
 # We can share the downloaded LLVM distribution with the first configuration.

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -153,7 +153,7 @@ use_repo(llvm, "llvm_toolchain_with_absolute_paths")
 # The llvm_version must match the version specified in .github/workflows/tests.yml: sys_paths_test
 llvm.toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = "16.0.0", 
+    llvm_versions = {"": "16.0.0"},
 )
 
 # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -63,10 +63,10 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 # When updating this version, also update the versions associated with
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
+# We use C++17 and the first LLVM version with full suppor is 16.0.0.
+# We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
 LLVM_VERSIONS = {
-    "": "16.0.0",
-    "darwin-aarch64": "16.0.5",
-    "darwin-x86_64": "15.0.7",
+    "": "first:>=17.0.0,<18",
 }
 
 llvm.toolchain(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -140,7 +140,7 @@ llvm_toolchain(
 # The llvm_version must match the version specified in .github/workflows/tests.yml: sys_paths_test
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = "16.0.0",
+    llvm_versions = {"": "16.0.0"},
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -57,7 +57,7 @@ LLVM_VERSIONS = {
 
 # Some tests do not yet work with LLVM versions > 16, so we define a separate
 # version set.
-LLVM_VERSIONS_16 = {
+LLVM_VERSIONS_15 = {
     "": "16.0.0",
     "darwin-aarch64": "16.0.5",
     "darwin-x86_64": "15.0.7",
@@ -73,12 +73,12 @@ llvm_toolchain(
 )
 
 llvm_toolchain(
-    name = "llvm_toolchain_16",
+    name = "llvm_toolchain_15",
     cxx_standard = {"": "c++17"},
     extra_target_compatible_with = {
         "": ["@//:cxx17"],
     },
-    llvm_versions = LLVM_VERSIONS_16,
+    llvm_versions = LLVM_VERSIONS_15,
 )
 
 llvm_toolchain(
@@ -143,7 +143,7 @@ llvm_toolchain(
 ## Toolchain example with system LLVM; tested in GitHub CI.
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS_16,
+    llvm_versions = LLVM_VERSIONS_15,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )
@@ -161,7 +161,7 @@ sysroot(
 
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = LLVM_VERSIONS_16,
+    llvm_versions = LLVM_VERSIONS_15,
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//sysroot",
     },

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -140,7 +140,7 @@ llvm_toolchain(
 # The llvm_version must match the version specified in .github/workflows/tests.yml: sys_paths_test
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = {"": "16.0.0"},
+    llvm_version = "getenv(LLVM_VERSION)",
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -62,16 +62,10 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 # We use C++17 and the first LLVM version with full suppor is 16.0.0.
 # We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
 # MacOS X86 does not exist for LLVM 17 or 18, so we allow 19 as well.
+# We also allow to override this with a environment LLVM_VERSION for testing.
 LLVM_VERSIONS = {
-    "": "first:>=17.0.0,<20",
-}
-
-# Some tests do not yet work with LLVM versions > 16, so we define a separate
-# version set.
-LLVM_VERSIONS_15 = {
-    "": "16.0.0",
-    "darwin-aarch64": "16.0.5",
-    "darwin-x86_64": "15.0.7",
+    "": "getenv(LLVM_VERSION,latest:>=17.0.0,<20)",
+    "darwin-x86_64": "15.0.7",  # Verify this works as opposed to using one version.
 }
 
 llvm_toolchain(
@@ -81,15 +75,6 @@ llvm_toolchain(
         "": ["@//:cxx17"],
     },
     llvm_versions = LLVM_VERSIONS,
-)
-
-llvm_toolchain(
-    name = "llvm_toolchain_15",
-    cxx_standard = {"": "c++17"},
-    extra_target_compatible_with = {
-        "": ["@//:cxx17"],
-    },
-    llvm_versions = LLVM_VERSIONS_15,
 )
 
 llvm_toolchain(
@@ -154,7 +139,7 @@ llvm_toolchain(
 ## Toolchain example with system LLVM; tested in GitHub CI.
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS_15,
+    llvm_versions = LLVM_VERSIONS,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )
@@ -172,7 +157,7 @@ sysroot(
 
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = LLVM_VERSIONS_15,
+    llvm_versions = LLVM_VERSIONS,
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//sysroot",
     },

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -137,9 +137,10 @@ llvm_toolchain(
 )
 
 ## Toolchain example with system LLVM; tested in GitHub CI.
+# The llvm_version must match the version specified in .github/workflows/tests.yml: sys_paths_test
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS,
+    llvm_versions = "16.0.0",
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -50,8 +50,9 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 # through the `llvm_toolchain_with_sysroot` toolchain.
 # We use C++17 and the first LLVM version with full suppor is 16.0.0.
 # We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
+# MacOS X86 does not exist for LLVM 17 or 18, so we allow 19 as well.
 LLVM_VERSIONS = {
-    "": "first:>=17.0.0,<18",
+    "": "first:>=17.0.0,<20",
 }
 
 llvm_toolchain(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -48,10 +48,10 @@ load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
 # When updating this version, also update the versions associated with
 # llvm_toolchain below, sys_paths_test in the workflows file, and xcompile_test
 # through the `llvm_toolchain_with_sysroot` toolchain.
+# We use C++17 and the first LLVM version with full suppor is 16.0.0.
+# We also use C++20 which has reasonable wide support starting with LLVM 17.0.0.
 LLVM_VERSIONS = {
-    "": "16.0.0",
-    "darwin-aarch64": "16.0.5",
-    "darwin-x86_64": "15.0.7",
+    "": "first:>=17.0.0,<18",
 }
 
 llvm_toolchain(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -55,6 +55,14 @@ LLVM_VERSIONS = {
     "": "first:>=17.0.0,<20",
 }
 
+# Some tests do not yet work with LLVM versions > 16, so we define a separate
+# version set.
+LLVM_VERSIONS_16 = {
+    "": "16.0.0",
+    "darwin-aarch64": "16.0.5",
+    "darwin-x86_64": "15.0.7",
+}
+
 llvm_toolchain(
     name = "llvm_toolchain",
     cxx_standard = {"": "c++17"},
@@ -62,6 +70,15 @@ llvm_toolchain(
         "": ["@//:cxx17"],
     },
     llvm_versions = LLVM_VERSIONS,
+)
+
+llvm_toolchain(
+    name = "llvm_toolchain_16",
+    cxx_standard = {"": "c++17"},
+    extra_target_compatible_with = {
+        "": ["@//:cxx17"],
+    },
+    llvm_versions = LLVM_VERSIONS_16,
 )
 
 llvm_toolchain(
@@ -126,7 +143,7 @@ llvm_toolchain(
 ## Toolchain example with system LLVM; tested in GitHub CI.
 llvm_toolchain(
     name = "llvm_toolchain_with_system_llvm",
-    llvm_versions = LLVM_VERSIONS,
+    llvm_versions = LLVM_VERSIONS_16,
     # For this toolchain to work, the LLVM distribution archive would need to be unpacked here.
     toolchain_roots = {"": "/opt/llvm-16"},
 )
@@ -144,7 +161,7 @@ sysroot(
 
 llvm_toolchain(
     name = "llvm_toolchain_with_sysroot",
-    llvm_versions = LLVM_VERSIONS,
+    llvm_versions = LLVM_VERSIONS_16,
     sysroot = {
         "linux-x86_64": "@org_chromium_sysroot_linux_x64//sysroot",
     },

--- a/tests/scripts/archlinux_test.sh
+++ b/tests/scripts/archlinux_test.sh
@@ -32,6 +32,6 @@ set -exuo pipefail
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh -t ${toolchain}
+tests/scripts/run_tests.sh -O -t ${toolchain}
 """
 done

--- a/tests/scripts/debian_test.sh
+++ b/tests/scripts/debian_test.sh
@@ -36,6 +36,6 @@ apt-get -qq -y install curl libtinfo5 libxml2 zlib1g-dev >/dev/null
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh
+tests/scripts/run_tests.sh -O
 """
 done

--- a/tests/scripts/fedora_test.sh
+++ b/tests/scripts/fedora_test.sh
@@ -32,6 +32,6 @@ dnf install -qy glibc-headers ncurses-compat-libs
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh
+tests/scripts/run_tests.sh -O
 """
 done

--- a/tests/scripts/linux_sysroot_test.sh
+++ b/tests/scripts/linux_sysroot_test.sh
@@ -19,6 +19,8 @@ images=(
   "ubuntu:22.04"
 )
 
+LLVM_VERSION="first:>=15.0.0,<17"
+
 git_root=$(git rev-parse --show-toplevel)
 readonly git_root
 
@@ -36,6 +38,6 @@ apt-get -qq -y install curl libtinfo5 libxml2 zlib1g-dev >/dev/null
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh -t '@llvm_toolchain_with_sysroot//:cc-toolchain-x86_64-linux'
+tests/scripts/run_tests.sh -t '@llvm_toolchain_with_sysroot//:cc-toolchain-x86_64-linux' -v '${LLVM_VERSION}'
 """
 done

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -71,7 +71,7 @@ fi
 # value is only possible by creating a custom rule which is overly complex here.
 if [[ -n "${toolchain_name}" ]]; then
   omp_target="${toolchain_name/\/\/*/}"
-  test_args+=("--define omp=${omp_target/#@/}")
+  test_args+=("--define" "omp=${omp_target/#@/}")
 fi
 
 "${bazel}" ${TEST_MIGRATION:+"--strict"} --bazelrc=/dev/null test \

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -72,10 +72,16 @@ fi
 if [[ -n "${toolchain_name}" ]]; then
   omp_target="${toolchain_name/\/\/*/}"
   test_args+=("--define" "omp=${omp_target/#@/}")
+  common_test_args+=(
+    "--platforms=@toolchains_llvm//platforms:linux-x86_64"
+  #  "--extra_execution_platforms=@toolchains_llvm//platforms:linux-x86_64"
+  )
 fi
 
 "${bazel}" ${TEST_MIGRATION:+"--strict"} --bazelrc=/dev/null test \
   "${common_test_args[@]}" "${test_args[@]}" "${targets[@]}"
+
+exit
 
 # Note that the following flags are currently known to cause issues in migration tests:
 # --incompatible_disallow_struct_provider_syntax # https://github.com/bazelbuild/bazel/issues/7347

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -66,18 +66,6 @@ if [[ -z "${toolchain_name}" ]]; then
   targets+=("//:test_cxx_standard_is_20")
 fi
 
-# If a toolchain is specified, set up OpenMP dependency accordingly.
-# We could just rewrite the BUILD files to depend on the correct omp target, but
-# it is preferable to leave the BUILD file alone and instead pass the correct
-# target via command line so that the BUILD files can be used in other contexts.
-# We do so using a combination of 'constraint_setting' and 'constraint_value'
-# whose possible values must be predefined in the BUILD file. Using the defined
-# value is only possible by creating a custom rule which is overly complex here.
-#if [[ -n "${toolchain_name}" ]]; then
-#  omp_target="${toolchain_name/\/\/*/}"
-#  common_test_args+=("--define" "omp=${omp_target/#@/}")
-#fi
-
 if [[ -n "${LLVM_VERSION}" ]]; then
   echo "LLVM_VERSION=${LLVM_VERSION}"
   common_test_args+=(

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -20,7 +20,7 @@ enable_omp_targets="1"
 enable_wasm_tests="1"
 LLVM_VERSION=""
 
-while getopts "ht:v:W" opt; do
+while getopts "hOt:v:W" opt; do
   case "${opt}" in
   "h")
     echo "Usage:"

--- a/tests/scripts/suse_leap_test.sh
+++ b/tests/scripts/suse_leap_test.sh
@@ -38,6 +38,6 @@ zypper -n install curl gcc libc++1
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh -t ${toolchain}
+tests/scripts/run_tests.sh -O -t ${toolchain}
 """
 done

--- a/tests/scripts/suse_tumbleweed_test.sh
+++ b/tests/scripts/suse_tumbleweed_test.sh
@@ -38,6 +38,6 @@ zypper -n install curl gcc libc++1
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh -t ${toolchain}
+tests/scripts/run_tests.sh -O -t ${toolchain}
 """
 done

--- a/tests/scripts/ubuntu_20_04_test.sh
+++ b/tests/scripts/ubuntu_20_04_test.sh
@@ -19,7 +19,7 @@ images=(
   "ubuntu:20.04"
 )
 
-toolchain="@llvm_toolchain_15//:cc-toolchain-x86_64-linux"
+LLVM_VERSION="first:>=15.0.0,<17"
 
 git_root=$(git rev-parse --show-toplevel)
 readonly git_root
@@ -42,6 +42,6 @@ disable_wasm_tests='-W'
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh -t ${toolchain} \${disable_wasm_tests}
+tests/scripts/run_tests.sh -v '${LLVM_VERSION}' \${disable_wasm_tests}
 """
 done

--- a/tests/scripts/ubuntu_20_04_test.sh
+++ b/tests/scripts/ubuntu_20_04_test.sh
@@ -40,6 +40,6 @@ disable_wasm_tests='-W'
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh \${disable_wasm_tests}
+tests/scripts/run_tests.sh -t'@llvm_toolchain_16//:cc-toolchain-x86_64-linux' \${disable_wasm_tests}
 """
 done

--- a/tests/scripts/ubuntu_20_04_test.sh
+++ b/tests/scripts/ubuntu_20_04_test.sh
@@ -19,7 +19,7 @@ images=(
   "ubuntu:20.04"
 )
 
-toolchain="@llvm_toolchain_16//:cc-toolchain-x86_64-linux"
+toolchain="@llvm_toolchain_15//:cc-toolchain-x86_64-linux"
 
 git_root=$(git rev-parse --show-toplevel)
 readonly git_root

--- a/tests/scripts/ubuntu_20_04_test.sh
+++ b/tests/scripts/ubuntu_20_04_test.sh
@@ -19,6 +19,8 @@ images=(
   "ubuntu:20.04"
 )
 
+toolchain="@llvm_toolchain_16//:cc-toolchain-x86_64-linux"
+
 git_root=$(git rev-parse --show-toplevel)
 readonly git_root
 
@@ -40,6 +42,6 @@ disable_wasm_tests='-W'
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh -t'@llvm_toolchain_16//:cc-toolchain-x86_64-linux' \${disable_wasm_tests}
+tests/scripts/run_tests.sh -t ${toolchain} \${disable_wasm_tests}
 """
 done

--- a/tests/scripts/ubuntu_22_04_test.sh
+++ b/tests/scripts/ubuntu_22_04_test.sh
@@ -36,6 +36,6 @@ apt-get -qq -y install curl libtinfo5 libxml2 zlib1g-dev >/dev/null
 
 # Run tests
 cd /src
-tests/scripts/run_tests.sh
+tests/scripts/run_tests.sh -O
 """
 done

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -38,7 +38,10 @@ load(
     _supported_targets = "SUPPORTED_TARGETS",
     _toolchain_tools = "toolchain_tools",
 )
-load("//toolchain/internal:llvm_distributions.bzl", "is_requirement", "required_llvm_release_name_rctx")
+load(
+    "//toolchain/internal:llvm_distributions.bzl",
+    _required_llvm_version_rctx = "required_llvm_version_rctx",
+)
 load(
     "//toolchain/internal:sysroot.bzl",
     _default_sysroot_path = "default_sysroot_path",
@@ -81,16 +84,7 @@ def llvm_config_impl(rctx):
 
     if not toolchain_root:
         fail("LLVM toolchain root missing for ({}, {})".format(os, arch))
-    _, llvm_version = _exec_os_arch_dict_value(rctx, "llvm_versions")
-    if is_requirement(llvm_version):
-        llvm_version, distribution, error = required_llvm_release_name_rctx(rctx, llvm_version)
-        if error:
-            fail(error)
-        if llvm_version:
-            print("\nINFO: Resolved latest LLVM version to {llvm_version}: {distribution}".format(
-                distribution = distribution,
-                llvm_version = llvm_version,
-            ))  # buildifier: disable=print
+    llvm_version = _required_llvm_version_rctx(rctx)
     if not llvm_version:
         # LLVM version missing for (os, arch)
         _empty_repository(rctx)

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1177,6 +1177,12 @@ def _resolve_llvm_version_rctx(rctx, llvm_version):
             env_name = env_var
             env_default = None
 
+        env_name = env_name.strip(" ")
+        if not env_var:
+            fail("ERROR: Bad getenv parameter '{env_var}'.".format(
+                env_var = env_var,
+            ))
+
         # We prefer 'repository_ctx.getenv' if it is available (~7.1+) and default
         # to accessing the environment directly. The latter breaks "hermeticity".
         if hasattr(rctx, "getenv"):
@@ -1186,10 +1192,10 @@ def _resolve_llvm_version_rctx(rctx, llvm_version):
         else:
             llvm_version = env_default
 
-        #print("\nINFO: Read environment variable '{env_var}' = '{llvm_version}'".format(
-        #    env_var = env_var,
-        #    llvm_version = llvm_version,
-        #))  # buildifier: disable=print
+        if not llvm_version:
+            fail("ERROR: Empty getenv lookup for '{env_var}'.".format(
+                env_var = env_var,
+            ))
 
     return llvm_version
 

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1138,7 +1138,9 @@ def _parse_version_or_requirements(version_or_requirements):
     for prefix in ["latest:", "first:"]:
         if version_or_requirements.startswith(prefix):
             return versions.parse_requirements(version_or_requirements.removeprefix(prefix))
-    if _is_requirement(version_or_requirements):
+    if version_or_requirements in ["latest", "first"]:
+        return None
+    if not _is_requirement(version_or_requirements):
         return None
     fail("ERROR: Invalid version requirements: '{version_or_requirements}'.".format(
         version_or_requirements = version_or_requirements,

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1160,10 +1160,11 @@ def _required_llvm_release_name(*, version_or_requirements, all_llvm_distributio
     return None, None, "ERROR: No matching distribution found."
 
 def required_llvm_release_name_rctx(rctx, llvm_version):
+    print("Determining required LLVM release for version/requirement: %s" % llvm_version)  # buildifier: disable=print
     all_llvm_distributions = _get_all_llvm_distributions(
         llvm_distributions = _llvm_distributions,
         extra_llvm_distributions = rctx.attr.extra_llvm_distributions,
-        parsed_llvm_version = _parse_version(llvm_version),
+        parsed_llvm_version = _parse_version(llvm_version) if not is_requirement(llvm_version) else None,
     )
     return _required_llvm_release_name(
         version_or_requirements = llvm_version,
@@ -1192,7 +1193,7 @@ def _distribution_urls(rctx):
     all_llvm_distributions = _get_all_llvm_distributions(
         llvm_distributions = _llvm_distributions,
         extra_llvm_distributions = rctx.attr.extra_llvm_distributions,
-        parsed_llvm_version = _parse_version(llvm_version),
+        parsed_llvm_version = _parse_version(llvm_version) if not is_requirement(llvm_version) else None,
     )
     _, sha256, strip_prefix, _ = _key_attrs(rctx)
 

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1160,7 +1160,6 @@ def _required_llvm_release_name(*, version_or_requirements, all_llvm_distributio
     return None, None, "ERROR: No matching distribution found."
 
 def required_llvm_release_name_rctx(rctx, llvm_version):
-    print("Determining required LLVM release for version/requirement: %s" % llvm_version)  # buildifier: disable=print
     all_llvm_distributions = _get_all_llvm_distributions(
         llvm_distributions = _llvm_distributions,
         extra_llvm_distributions = rctx.attr.extra_llvm_distributions,

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -1168,7 +1168,7 @@ def _required_llvm_release_name(*, version_or_requirements, all_llvm_distributio
             return llvm_version, basenames[0], None
     return None, None, "ERROR: No matching distribution found."
 
-def _resolve_llvm_version_rctx(rctx, llvm_version):
+def _resolve_llvm_version_rctx_env(rctx, llvm_version):
     if llvm_version.startswith("getenv(") and llvm_version.endswith(")"):
         env_var = llvm_version[len("getenv("):-1]
         if env_var.find(",") >= 0:
@@ -1200,7 +1200,7 @@ def _resolve_llvm_version_rctx(rctx, llvm_version):
     return llvm_version
 
 def _required_llvm_release_name_rctx(rctx, llvm_version):
-    llvm_version = _resolve_llvm_version_rctx(rctx, llvm_version)
+    llvm_version = _resolve_llvm_version_rctx_env(rctx, llvm_version)
     all_llvm_distributions = _get_all_llvm_distributions(
         llvm_distributions = _llvm_distributions,
         extra_llvm_distributions = rctx.attr.extra_llvm_distributions,
@@ -1246,8 +1246,8 @@ def _distribution_urls(rctx):
 
     if rctx.attr.distribution == "auto":
         rctx_host_info = host_info(rctx)
+        llvm_version = _resolve_llvm_version_rctx_env(rctx, llvm_version)
         if _is_requirement(llvm_version):
-            llvm_version = _resolve_llvm_version_rctx(rctx, llvm_version)
             llvm_version, basename, error = _required_llvm_release_name(
                 version_or_requirements = llvm_version,
                 all_llvm_distributions = all_llvm_distributions,

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -21,6 +21,8 @@ load(
 load(
     "//toolchain/internal:llvm_distributions.bzl",
     _download_llvm = "download_llvm",
+    _is_requirement = "is_requirement",
+    _required_llvm_release_name_rctx = "required_llvm_release_name_rctx",
 )
 
 _target_pairs = ", ".join(_supported_os_arch_keys())
@@ -424,6 +426,16 @@ def llvm_repo_impl(rctx):
         return None
 
     _, llvm_version = _exec_os_arch_dict_value(rctx, "llvm_versions")
+
+    if _is_requirement(llvm_version):
+        llvm_version, distribution, error = _required_llvm_release_name_rctx(rctx, llvm_version)
+        if error:
+            fail(error)
+        if llvm_version:
+            print("\nINFO: Resolved latest LLVM version to {llvm_version}: {distribution}".format(
+                distribution = distribution,
+                llvm_version = llvm_version,
+            ))  # buildifier: disable=print
 
     major_llvm_version = int(llvm_version.split(".")[0])
 

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -14,15 +14,13 @@
 load(
     "//toolchain/internal:common.bzl",
     _attr_dict = "attr_dict",
-    _exec_os_arch_dict_value = "exec_os_arch_dict_value",
     _os = "os",
     _supported_os_arch_keys = "supported_os_arch_keys",
 )
 load(
     "//toolchain/internal:llvm_distributions.bzl",
     _download_llvm = "download_llvm",
-    _is_requirement = "is_requirement",
-    _required_llvm_release_name_rctx = "required_llvm_release_name_rctx",
+    _required_llvm_version_rctx = "required_llvm_version_rctx",
 )
 
 _target_pairs = ", ".join(_supported_os_arch_keys())
@@ -425,18 +423,7 @@ def llvm_repo_impl(rctx):
         rctx.file("BUILD.bazel", executable = False)
         return None
 
-    _, llvm_version = _exec_os_arch_dict_value(rctx, "llvm_versions")
-
-    if _is_requirement(llvm_version):
-        llvm_version, distribution, error = _required_llvm_release_name_rctx(rctx, llvm_version)
-        if error:
-            fail(error)
-        if llvm_version:
-            print("\nINFO: Resolved latest LLVM version to {llvm_version}: {distribution}".format(
-                distribution = distribution,
-                llvm_version = llvm_version,
-            ))  # buildifier: disable=print
-
+    llvm_version = _required_llvm_version_rctx(rctx)
     major_llvm_version = int(llvm_version.split(".")[0])
 
     rctx.file(


### PR DESCRIPTION
Allow attribute llvm_versions to specify version requirements.

Update some (main and test) dependencies.
Mark omp targets as manual (likely to be normal in a follow up).
Allow llvm_version to be taken from environment (or bazel command line). This does for newer bazel versions respect hermeticity.
Simplify version handling and log the resolution only in one place.
Update default llvm target version to "latest:>=17.0.0,<20" (e.g. 19) but allow environment overrides.