### PR TITLE
Correctly update rules_rust

### DIFF
--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -294,9 +294,8 @@ go_download_sdk(
 # For testing rules_rust.
 
 http_archive(
-    name = "rules_rust",
-    sha256 = "af4f56caae50a99a68bfce39b141b509dd68548c8204b98ab7a1cafc94d5bb02",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.54.1/rules_rust-v0.54.1.tar.gz"],
+    integrity = "sha256-3Ch+PsqAsp1cyV4mHK4nPu3xr0oAqWrpN+I0U02tskw=",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.67.0/rules_rust-0.67.0.tar.gz"],
 )
 
 load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -294,6 +294,7 @@ go_download_sdk(
 # For testing rules_rust.
 
 http_archive(
+    name = "rules_rust",
     integrity = "sha256-3Ch+PsqAsp1cyV4mHK4nPu3xr0oAqWrpN+I0U02tskw=",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.67.0/rules_rust-0.67.0.tar.gz"],
 )


### PR DESCRIPTION
Replaces https://github.com/bazel-contrib/toolchains_llvm/pull/419 where the bot fails to do it correctly.