### PR TITLE
Update rules_go to 0.59.0

### DIFF
--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -38,6 +38,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     version = "1.25.3",
 )
+use_repo(go_sdk, "go_toolchains")
 
 register_toolchains("@go_toolchains//:all")
 

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_rust", version = "0.67.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
@@ -36,10 +36,8 @@ bazel_dep(name = "rules_python", version = "1.6.3")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
-    name = "go_sdk",
-    version = "1.21.0",
+    version = "1.25.3",
 )
-use_repo(go_sdk, "go_toolchains")
 
 register_toolchains("@go_toolchains//:all")
 

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -36,7 +36,7 @@ bazel_dep(name = "rules_python", version = "1.6.3")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
-    version = "1.25.3",
+    version = "1.25.4",
 )
 use_repo(go_sdk, "go_toolchains")
 

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -275,20 +275,26 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
+    sha256 = "68af54cb97fbdee5e5e8fe8d210d15a518f9d62abfd71620c3eaff3b26a5ff86",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
+        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip",
+        "https://github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip",
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_download_sdk(
-    name = "go_sdk",
-    version = "1.21.0",
+go_register_toolchains(version = "1.25.4")
+
+# Create the host platform repository transitively required by rules_go.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+    host_platform_repo,
+    name = "host_platform",
 )
 
 # For testing rules_rust.
@@ -386,7 +392,5 @@ http_archive(
         "https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz",
     ],
 )
-
-load("@platforms//host:extension.bzl", "host_platform_repo")
 
 host_platform_repo(name = "host_platform")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -392,5 +392,3 @@ http_archive(
         "https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz",
     ],
 )
-
-host_platform_repo(name = "host_platform")

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -29,14 +29,14 @@ echo "Output base: ${output_base}"
 
 # As of rules_go 0.51.0 the 'generate_imported_dylib.sh' expects 'cc' to be available through PATH.
 if [[ ${USE_BZLMOD} == "true" ]]; then
-  script="${output_base}/external/rules_go~/tests/core/cgo/generate_imported_dylib.sh"
-  if [[ ! -f "${script}" ]]; then
-    script="${output_base}/external/rules_go+/tests/core/cgo/generate_imported_dylib.sh"
+  generate_imported_dylib_sh="${output_base}/external/rules_go~/tests/core/cgo/generate_imported_dylib.sh"
+  if [[ ! -f "${generate_imported_dylib_sh}" ]]; then
+    generate_imported_dylib_sh="${output_base}/external/rules_go+/tests/core/cgo/generate_imported_dylib.sh"
   fi
 else
-  script="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
+  generate_imported_dylib_sh="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
 fi
-"${script}" || echo "Generating imported dylib failed."
+"${generate_imported_dylib_sh}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
 
 test_args=(
   "${common_test_args[@]}"


### PR DESCRIPTION
The cause that prevented automatic updates is the hardcoded `cc` in rule_go's tests/core/cgo/generate_imported_dylib.sh

We also disable the following tests:
* @io_bazel_rules_go//tests/core/cgo:cgo_abs_paths_test
* @io_bazel_rules_go//tests/core/cgo:wrapped_cgo_test

This is related to https://github.com/bazel-contrib/toolchains_llvm/issues/503