### PR TITLE
chore: fix llvm_checksums.sh and update LLVM 22.1.2-22.1.4 checksums

### DIFF
--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -740,13 +740,37 @@ _llvm_distributions = {
 
     # 22.1.1
     "clang+llvm-22.1.1-aarch64-pc-windows-msvc.tar.xz": "sha256:54897a70f7c4fa9d66cd1cb280a3a223a0c70f7abaee1322c78beeeb89af4682",
+    "clang+llvm-22.1.1-armv7a-linux-gnueabihf.tar.gz": "sha256:0618593cfc36567c9b19f3d36b8bece9a2c91bf0d26f3115b4c6f8a9f6841dd4",
     "clang+llvm-22.1.1-x86_64-pc-windows-msvc.tar.xz": "sha256:186f17ebedf13bae2835b2c0d5111a2a469ac241e7fc6387c9ce4585d6ef56ed",
     "LLVM-22.1.1-Linux-ARM64.tar.xz": "sha256:a807a16a4dd9a288b6ad3d507df4eae47dfdfbccab118170ebd216b85370a065",
     "LLVM-22.1.1-Linux-X64.tar.xz": "sha256:efc4d945744f951df00ec72c5b31da5d5a2eaf1d53cc7c9d0644f93f0f9e817d",
     "LLVM-22.1.1-macOS-ARM64.tar.xz": "sha256:3839802601439300fc8d1d378bc26732e879e1ca80a220f7d6764ed229053e92",
 
+    # 22.1.2
+    "clang+llvm-22.1.2-aarch64-pc-windows-msvc.tar.xz": "sha256:16b9755d6335bfb54a51f6f676233df75f06d29ce627c2b402b90171b0e88456",
+    "clang+llvm-22.1.2-armv7a-linux-gnueabihf.tar.gz": "sha256:cb47f4b7cd3e2395b21074f00e642aa8b0d2b9a8547ca6b195d19b22e8f7e7d1",
+    "clang+llvm-22.1.2-x86_64-pc-windows-msvc.tar.xz": "sha256:6550bcc308bf972f7f956001b73f6478da3d22f1ebd4b01653c978a6c7ff3698",
+    "LLVM-22.1.2-Linux-ARM64.tar.xz": "sha256:cf2e84d965a95954971cafc71d18c0eb38e723c3ac7276286fd5636df4374b3a",
+    "LLVM-22.1.2-Linux-X64.tar.xz": "sha256:ff32497b6801267ee427bc69cdaeecfb2d19578af8c2a942e864c45215f9a2ac",
+    "LLVM-22.1.2-macOS-ARM64.tar.xz": "sha256:7b290ec4529c309b6b952d64a3513595c816dff1c217d54466a586d6e35dcec9",
+
+    # 22.1.3
+    "clang+llvm-22.1.3-aarch64-pc-windows-msvc.tar.xz": "sha256:b593bea1751c3c1825886743e2ee4ec9b63f3ca9b5b2aa1b467da69657681fe5",
+    "clang+llvm-22.1.3-armv7a-linux-gnueabihf.tar.gz": "sha256:6976851facdb878a05a7a466c6739568e7dbdac2d13ae65c026cfa7b6fa563e3",
+    "clang+llvm-22.1.3-x86_64-pc-windows-msvc.tar.xz": "sha256:f2d7d200f72c83880aa2c1c00f6b6a67d0ea607ea663dafbd0cb2db6e2819ed0",
+    "LLVM-22.1.3-Linux-ARM64.tar.xz": "sha256:4dc01fbb46084b3c3304a51e8412903da3735d5a276bcdd35333bc38bad8a8b6",
+    "LLVM-22.1.3-Linux-X64.tar.xz": "sha256:6e776c396895837a168a36d13e0b0e4552680eda58d8dab6aa5fb75e2c3d13ea",
+    "LLVM-22.1.3-macOS-ARM64.tar.xz": "sha256:881e524d374cd2befd95888db1846e3150b0728fa842b90bb15bafc0b19c075c",
+
+    # 22.1.4
+    "clang+llvm-22.1.4-aarch64-pc-windows-msvc.tar.xz": "sha256:958e314fc28968c3895a61c0b9ae54c9e4ec7a409ec4b59cc02c9c6a0ae90be4",
+    "clang+llvm-22.1.4-x86_64-pc-windows-msvc.tar.xz": "sha256:ed775bdaea7087c6c1aeac9498352cfcd8610d92dc4fe9eda9aecb15ce712a2c",
+    "LLVM-22.1.4-Linux-ARM64.tar.xz": "sha256:ac8bed48a6481ccc0e14af18f64d44fc1ca8c0ccf630c1d4dc5e97027e87e6fa",
+    "LLVM-22.1.4-Linux-X64.tar.xz": "sha256:cdf232e3bc5d9909ddcf8cb7016802c6745a01e69a596747c684caa894a11567",
+    "LLVM-22.1.4-macOS-ARM64.tar.xz": "sha256:45e0dfc0453624caed5e7b20e224ce8343af9c511c7f59803753a586620d6ad1",
+
     # Refer to variable declaration on how to update!
-    # Example update (without download): utils/llvm_checksums.sh -D -g -t /tmp/llvm -v 21.1.5
+    # Example update (without download): utils/llvm_checksums.sh -g -t /tmp/llvm -v 21.1.5
 }
 
 # Note: Unlike the user-specified llvm_mirror attribute, the URL prefixes in

--- a/toolchain/internal/llvm_distributions.golden.out.txt
+++ b/toolchain/internal/llvm_distributions.golden.out.txt
@@ -79,6 +79,9 @@ version: 21.1.7
 version: 21.1.8
 version: 22.1.0
 version: 22.1.1
+version: 22.1.2
+version: 22.1.3
+version: 22.1.4
 del: clang+llvm-9.0.0-x86_64-pc-linux-gnu.tar.xz
 del: clang+llvm-15.0.2-x86_64-unknown-linux-gnu-sles15.tar.xz
 del: clang+llvm-19.1.0-x86_64-pc-windows-msvc.tar.xz

--- a/utils/llvm_checksums.sh
+++ b/utils/llvm_checksums.sh
@@ -17,21 +17,23 @@ set -euo pipefail
 
 use_github_host=0
 tmp_dir=
-download=1
+download=0
 
-while getopts "t:v:ghD" opt; do
+while getopts "t:v:ghDd" opt; do
   case "${opt}" in
-  "t") tmp_dir="${OPTARG}" ;;
-  "v") llvm_version="${OPTARG}" ;;
+  "d") download=1 ;;
+  "D") download=0 ;;
   "g") use_github_host=1 ;;
   "h")
     echo "Usage:"
     echo "-t <tempdir> - Optional: Specify a temp directory to download distributions to."
     echo "-v <version> - Version of clang+llvm to use."
     echo "-g           - Use github to download releases."
+    echo "-d           - Download the distribution tarballs."
     exit 2
     ;;
-  "D") download=0 ;;
+  "t") tmp_dir="${OPTARG}" ;;
+  "v") llvm_version="${OPTARG}" ;;
   *)
     echo "invalid option: -${OPTARG}"
     exit 1
@@ -40,7 +42,7 @@ while getopts "t:v:ghD" opt; do
 done
 
 if [[ -z ${llvm_version-} ]]; then
-  echo "Usage: ${BASH_SOURCE[0]} [-t <tempdir>] [-g] -v <llvm_version>"
+  echo "Usage: ${BASH_SOURCE[0]} [-t <tempdir>] [-g] [-d] -v <llvm_version>"
   exit 1
 fi
 
@@ -54,9 +56,8 @@ if [[ -z "${tmp_dir}" ]]; then
   tmp_dir="$(mktemp -d)"
   echo "Using temp dir: '${tmp_dir}'"
   trap 'cleanup' INT HUP QUIT TERM EXIT
-elif [[ ! -r "${tmp_dir}" ]]; then
-  echo "Temp directory does not exist: '${tmp_dir}'."
-  exit 2
+else
+  mkdir -p "${tmp_dir}"
 fi
 
 llvm_host() {
@@ -69,24 +70,29 @@ llvm_host() {
 github_host() {
   output_dir="${tmp_dir}/${llvm_version}"
   mkdir -p "${output_dir}"
+
+  # Fetch release JSON and extract asset info
+  curl -s "https://api.github.com/repos/llvm/llvm-project/releases/tags/llvmorg-${llvm_version}" |
+    tee "${output_dir}/releases.json" |
+    jq -r '.assets[]|select(any(.name; test("^(clang[+]llvm|LLVM)-.*tar.(xz|gz)$")))|"    \""+(.browser_download_url|split("/")|.[-1]|sub("%2B";"+"))+"\": \""+.digest+"\","' \
+      >"${output_dir}/checksums.txt"
+
   if ((download)); then
-    echo ""
+    # Download the actual tarballs using the already-fetched JSON
+    jq -r '.assets[]|select(any(.name; test("^(clang[+]llvm|LLVM)-.*tar.(xz|gz)$")))|.browser_download_url' \
+      "${output_dir}/releases.json" \
+      >"${output_dir}/filtered_urls.txt"
+    (
+      cd "${output_dir}"
+      xargs -n1 curl -L -O -C - <filtered_urls.txt
+    )
+  else
     echo "===="
     echo "Checksums for clang+llvm distributions are (${output_dir}):"
     echo "    # ${llvm_version}"
-    curl -s "https://api.github.com/repos/llvm/llvm-project/releases/tags/llvmorg-${llvm_version}" |
-      tee ./releases.json |
-      jq -r '.assets[]|select(any(.name; test("^(clang[+]llvm|LLVM)-.*tar.(xz|gz)$")))|"    \""+(.browser_download_url|split("/")|.[-1]|sub("%2B";"+"))+"\": \""+.digest+"\","'
+    cat "${output_dir}/checksums.txt"
     exit 0
   fi
-  (
-    cd "${output_dir}"
-    curl -s "https://api.github.com/repos/llvm/llvm-project/releases/tags/llvmorg-${llvm_version}" |
-      tee ./releases.json |
-      jq '.assets[]|select(any(.name .digest; test("^(clang[+]llvm|LLVM)-.*tar.(xz|gz)$")))|.browser_download_url' |
-      tee ./filtered_urls.txt |
-      xargs -n1 curl -L -O -C -
-  )
 }
 
 if ((use_github_host)); then


### PR DESCRIPTION
## Summary
- Fix `github_host()` hanging in download mode — the pipeline `jq | tee | xargs curl` kept the pipe open indefinitely
- GitHub API is now called only once; `releases.json` is reused for both checksum output and tarball download
- Make download opt-in with `-d` flag (default disabled), alphabetized option flags
- Create user-specified tmp dir with `mkdir -p` instead of failing
- Add distribution checksums for LLVM 22.1.2, 22.1.3, and 22.1.4

## Test plan
- [x] Run `utils/llvm_checksums.sh -g -t /tmp/llvm -v 22.1.4` — should output checksums without downloading
- [x] Run `utils/llvm_checksums.sh -g -d -t /tmp/llvm -v 22.1.4` — should download tarballs and output checksums
- [x] Verify existing golden output matches with `bazel test //toolchain/internal:llvm_distributions_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)