### PR TITLE
Export cc-wrapper from LLVM toolchain repo

### DIFF
--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -37,6 +37,13 @@ filegroup(
     visibility = ["//visibility:private"],
 )
 
+filegroup(
+    name = "cc-wrapper",
+    srcs = [
+        "%{wrapper_bin_prefix}cc_wrapper.sh",
+    ],
+)
+
 %{cc_toolchains}
 
 # Convenience targets from the LLVM toolchain.


### PR DESCRIPTION
I have a hybrid build setup that mixes Bazel and non-Bazel targets.

For the non-Bazel side, I need to reuse the generated Clang wrapper outside the toolchain rule so it can be packaged and invoked by external build steps.

This change exports the wrapper via a public filegroup.
