### PR TITLE
chore: ignore .trunk/out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /toolchain/tools/host_os_key.pyc
 MODULE.bazel.lock
 /.bazelrc.user
+/.trunk/out


### PR DESCRIPTION
## Summary
- Add `/.trunk/out` to `.gitignore` to prevent accidental commits of tool output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)