### PR TITLE
download_llvm: keep bundled-distro fallback reproducible

### DIFF
--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -858,6 +858,7 @@ def download_llvm(rctx):
             update_sha256 = True
     if not urls:
         urls, sha256, strip_prefix = _distribution_urls(rctx)
+
         # The bundled distribution table provides its own sha256, so there
         # is nothing to record back into the rule's attrs. Leaving
         # update_sha256 set here would make `download_llvm` write

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -858,6 +858,14 @@ def download_llvm(rctx):
             update_sha256 = True
     if not urls:
         urls, sha256, strip_prefix = _distribution_urls(rctx)
+        # The bundled distribution table provides its own sha256, so there
+        # is nothing to record back into the rule's attrs. Leaving
+        # update_sha256 set here would make `download_llvm` write
+        # `rctx.attr.sha256[""]` post-extract and put `llvm_repo_impl` on
+        # the `repo_metadata(attrs_for_reproducibility=...)` branch, which
+        # `--repo_contents_cache` does not symlink-share across output
+        # bases.
+        update_sha256 = False
 
     sha256, shaerr = _normalize_and_check_sha256(sha256)
     if shaerr:


### PR DESCRIPTION
When a user sets `urls` on `llvm.toolchain(...)` for some platforms but not all, hosts on the unmatched platforms fall through to the bundled distribution table, and `download_llvm` then breaks reproducibility reporting in a way that disables `--repo_contents_cache` symlink-sharing for the LLVM dist.

Concretely, in `toolchain/internal/llvm_distributions.bzl::download_llvm`:

```python
if rctx.attr.urls:
    urls, sha256, strip_prefix, key = _urls(rctx)   # key="", urls=None on unmatched host
    if not sha256:
        update_sha256 = True                         # <- fires
if not urls:
    urls, sha256, strip_prefix = _distribution_urls(rctx)   # bundled table, has its own sha256
```

This means every output_base ends up with its own freshly-extracted ~7 GB copy of the LLVM dist rather than a symlink into the shared cache.

Fix is to clear `update_sha256` after the bundled fallback

Note/context: working in a monorepo, and as a heavy user of git worktrees, I've been finding disk bloat, as each worktree gets a copy of LLVM extracted.  I investigated this, and got a working patch internally.  To upstream, this is my first contrib to this repo, so worth noting in case I've misunderstood something
