### PR TITLE
ci: add stdlib matrix testing (libc++, stdc++, dynamic-stdc++)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,15 @@ jobs:
         bzlmod: [true, false]
         stdlib: [default, libc++, stdc++, dynamic-stdc++]
         exclude:
-          - bazel_version: latest # bazel latest does not need bzlmod=false
+          - os: macos-latest
+            stdlib: libc++ # Needs to be installed first
+          - os: macos-latest
+            stdlib: stdc++ # Needs to be installed first
+          - os: macos-latest
+            stdlib: dynamic-stdc++ # Needs to be installed first
+          - bazel_version: latest
             bzlmod: false
-          - bzlmod: false # bzlmod=false only tests the default (builtin-libc++) stdlib
+          - bzlmod: false # Only test the default stdlib: builtin-libc++
             stdlib: libc++
           - bzlmod: false
             stdlib: stdc++

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,17 +61,28 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        bazel_version: [latest] # rules_rust bzlmod support is experimental and needs latest version as of now (20230912).
+        bazel_version: [8.*, latest]
         bzlmod: [true, false]
+        stdlib: [default, libc++, stdc++, dynamic-stdc++]
+        exclude:
+          - bazel_version: latest # bazel latest does not need bzlmod=false
+            bzlmod: false
+          - bzlmod: false # bzlmod=false only tests the default (builtin-libc++) stdlib
+            stdlib: libc++
+          - bzlmod: false
+            stdlib: stdc++
+          - bzlmod: false
+            stdlib: dynamic-stdc++
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - if: startsWith(matrix.os, 'ubuntu')
         run: tests/scripts/ubuntu_install_libtinfo.sh
-      - name: Test
+      - name: Test (${{ matrix.stdlib }})
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
           USE_BZLMOD: ${{ matrix.bzlmod }}
+          TEST_STDLIB: ${{ matrix.stdlib }}
         run: tests/scripts/run_external_tests.sh
   container_test:
     strategy:

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -96,6 +96,30 @@ use_repo(llvm, "llvm_toolchain_cxx20")
 
 register_toolchains("@llvm_toolchain_cxx20//:all")
 
+# Toolchain examples for testing different stdlib implementations on Linux.
+# These are used by run_external_tests.sh in CI to verify that the toolchain
+# works with system-hosted libc++ and libstdc++ instead of the builtin libc++.
+llvm.toolchain(
+    name = "llvm_toolchain_libcxx",
+    stdlib = {"": "libc++"},
+    llvm_versions = LLVM_VERSIONS,
+)
+use_repo(llvm, "llvm_toolchain_libcxx")
+
+llvm.toolchain(
+    name = "llvm_toolchain_stdcpp",
+    stdlib = {"": "stdc++"},
+    llvm_versions = LLVM_VERSIONS,
+)
+use_repo(llvm, "llvm_toolchain_stdcpp")
+
+llvm.toolchain(
+    name = "llvm_toolchain_dynamic_stdcpp",
+    stdlib = {"": "dynamic-stdc++"},
+    llvm_versions = LLVM_VERSIONS,
+)
+use_repo(llvm, "llvm_toolchain_dynamic_stdcpp")
+
 # Example toolchain with user provided URLs.
 # TODO(siddharthab): Add test.
 llvm.toolchain(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -279,6 +279,13 @@ http_archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
 )
 
+http_archive(
+    name = "google_benchmark",
+    sha256 = "9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340",
+    strip_prefix = "benchmark-1.9.5",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+)
+
 # As a test dep of com_google_absl.
 http_archive(
     name = "googletest",

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -289,6 +289,7 @@ http_archive(
 
 http_archive(
     name = "boringssl",
+    patch_args = ["-p1"],
     patches = ["//:boringssl-20260413.0.patch"],
     sha256 = "de3371d3fe085afd34778a4c988fb7840b9c92cb21504e674f33ebefd98edc00",
     strip_prefix = "boringssl-0.20260508.0",

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -289,6 +289,8 @@ http_archive(
 
 http_archive(
     name = "boringssl",
+    patch_strip = 1,
+    patches = ["//:boringssl-20260413.0.patch"],
     sha256 = "de3371d3fe085afd34778a4c988fb7840b9c92cb21504e674f33ebefd98edc00",
     strip_prefix = "boringssl-0.20260508.0",
     urls = ["https://github.com/google/boringssl/releases/download/0.20260508.0/boringssl-0.20260508.0.tar.gz"],

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -86,6 +86,27 @@ llvm_toolchain(
     llvm_versions = LLVM_VERSIONS,
 )
 
+# Toolchain examples for testing different stdlib implementations on Linux.
+# These are used by run_external_tests.sh in CI to verify that the toolchain
+# works with system-hosted libc++ and libstdc++ instead of the builtin libc++.
+llvm_toolchain(
+    name = "llvm_toolchain_libcxx",
+    llvm_versions = LLVM_VERSIONS,
+    stdlib = {"": "libc++"},
+)
+
+llvm_toolchain(
+    name = "llvm_toolchain_stdcpp",
+    llvm_versions = LLVM_VERSIONS,
+    stdlib = {"": "stdc++"},
+)
+
+llvm_toolchain(
+    name = "llvm_toolchain_dynamic_stdcpp",
+    llvm_versions = LLVM_VERSIONS,
+    stdlib = {"": "dynamic-stdc++"},
+)
+
 # Example toolchain with user provided URLs.
 # TODO(siddharthab): Add test.
 llvm_toolchain(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -289,7 +289,6 @@ http_archive(
 
 http_archive(
     name = "boringssl",
-    patch_strip = 1,
     patches = ["//:boringssl-20260413.0.patch"],
     sha256 = "de3371d3fe085afd34778a4c988fb7840b9c92cb21504e674f33ebefd98edc00",
     strip_prefix = "boringssl-0.20260508.0",

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -75,6 +75,8 @@ targets=(
 # only run rust-related prep and tests on bazel 9+ with bzlmod enabled.
 _use_bazel_version="${USE_BAZEL_VERSION:-latest}"
 if [[ "${_use_bazel_version}" != "8."* ]] && [[ "${USE_BZLMOD:-true}" == "true" ]]; then
+  echo "------------------------------------------------------"
+  echo "Running extra prep steps for rules_rust tests (bazel ${_use_bazel_version} with bzlmod)..."
   # Generate files needed for rules_go cgo tests.
   "${bazel}" query "${common_args[@]}" @io_bazel_rules_go//tests/core/cgo:dylib_test >/dev/null
 
@@ -90,7 +92,6 @@ if [[ "${_use_bazel_version}" != "8."* ]] && [[ "${USE_BZLMOD:-true}" == "true" 
   else
     generate_imported_dylib_sh="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
   fi
-  echo "------------------------------------------------------"
   echo "Script: '${generate_imported_dylib_sh}'"
   "${generate_imported_dylib_sh}" "${IMPORTED_C_PATH-}" "${OUTPUT_DIR:-${output_base}}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
   echo "------------------------------------------------------"

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -51,24 +51,43 @@ if [[ -n "${toolchain_name}" ]]; then
   common_test_args+=("--extra_toolchains=${toolchain_name}")
 fi
 
-"${bazel}" query "${common_args[@]}" @io_bazel_rules_go//tests/core/cgo:dylib_test >/dev/null
+# Extra test targets (e.g. rules_rust) that require bazel >= 9 and bzlmod.
+targets=()
 
-output_base="$("${bazel}" info output_base)"
-echo "Output base: ${output_base}"
+# rules_rust bzlmod support is unreliable on older Bazel versions;
+# only run rust-related prep and tests on bazel 9+ with bzlmod enabled.
+_use_bazel_version="${USE_BAZEL_VERSION:-latest}"
+if [[ "${_use_bazel_version}" != "8."* ]] && [[ "${USE_BZLMOD:-true}" == "true" ]]; then
+  # Generate files needed for rules_go cgo tests.
+  "${bazel}" query "${common_args[@]}" @io_bazel_rules_go//tests/core/cgo:dylib_test >/dev/null
 
-# As of rules_go 0.51.0 the 'generate_imported_dylib.sh' expects 'cc' to be available through PATH.
-if [[ ${USE_BZLMOD:-true} == "true" ]]; then
-  generate_imported_dylib_sh="${output_base}/external/rules_go~/tests/core/cgo/generate_imported_dylib.sh"
-  if [[ ! -f ${generate_imported_dylib_sh} ]]; then
-    generate_imported_dylib_sh="${output_base}/external/rules_go+/tests/core/cgo/generate_imported_dylib.sh"
+  output_base="$("${bazel}" info output_base)"
+  echo "Output base: ${output_base}"
+
+  # As of rules_go 0.51.0 the 'generate_imported_dylib.sh' expects 'cc' to be available through PATH.
+  if [[ ${USE_BZLMOD:-true} == "true" ]]; then
+    generate_imported_dylib_sh="${output_base}/external/rules_go~/tests/core/cgo/generate_imported_dylib.sh"
+    if [[ ! -f ${generate_imported_dylib_sh} ]]; then
+      generate_imported_dylib_sh="${output_base}/external/rules_go+/tests/core/cgo/generate_imported_dylib.sh"
+    fi
+  else
+    generate_imported_dylib_sh="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
   fi
-else
-  generate_imported_dylib_sh="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
+  echo "Script: '${generate_imported_dylib_sh}'"
+  echo "------------------------------------------------------"
+  "${generate_imported_dylib_sh}" "${IMPORTED_C_PATH-}" "${OUTPUT_DIR:-${output_base}}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
+  echo "------------------------------------------------------"
+
+  targets+=(
+    "@rules_rust//test/unit/{interleaved_cc_info,native_deps}:all"
+    "@io_bazel_rules_go//tests/core/cgo:all"
+    "-@io_bazel_rules_go//tests/core/cgo:cc_libs_test"
+    "-@io_bazel_rules_go//tests/core/cgo:cgo_abs_paths_test"
+    "-@io_bazel_rules_go//tests/core/cgo:external_includes_test"
+    "-@io_bazel_rules_go//tests/core/cgo:wrapped_cgo_test"
+    "-@rules_rust//test/unit/native_deps:{cdylib,bin}_has_native_dep_and_alwayslink_{cc,rust}_linker_test"
+  )
 fi
-echo "Script: '${generate_imported_dylib_sh}'"
-echo "------------------------------------------------------"
-"${generate_imported_dylib_sh}" "${IMPORTED_C_PATH-}" "${OUTPUT_DIR:-${output_base}}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
-echo "------------------------------------------------------"
 
 test_args=(
   "${common_test_args[@]}"
@@ -96,19 +115,11 @@ echo "Bazel test args: ${test_args[*]}"
 #   to run, and it is not particularly useful to us.
 # - time_zone_format_test from abseil-cpp because it assumes TZ is set to America/Los_Angeles, but
 #   we run the tests in UTC.
-# - {cdylib,bin}_has_native_dep_and_alwayslink_{cc,rust}_linkertest from rules_rust because they assume the test is
-#    being run in the root module (use 'rules_rust' in the bazel-bin path instead of 'rules_rust~').
 # shellcheck disable=SC2207
 absl_targets=($("${bazel}" query "${common_args[@]}" 'attr(timeout, short, tests(@com_google_absl//absl/...) except attr(tags, benchmark, tests(@com_google_absl//absl/...)))'))
 "${bazel}" --bazelrc=/dev/null test "${test_args[@]}" -- \
   //foreign:pcre \
   @boringssl//... \
-  @rules_rust//test/unit/{interleaved_cc_info,native_deps}:all \
-  @io_bazel_rules_go//tests/core/cgo:all \
-  -@io_bazel_rules_go//tests/core/cgo:cc_libs_test \
-  -@io_bazel_rules_go//tests/core/cgo:cgo_abs_paths_test \
-  -@io_bazel_rules_go//tests/core/cgo:external_includes_test \
-  -@io_bazel_rules_go//tests/core/cgo:wrapped_cgo_test \
-  -@rules_rust//test/unit/native_deps:{cdylib,bin}_has_native_dep_and_alwayslink_{cc,rust}_linker_test \
+  "${targets[@]}" \
   "${absl_targets[@]}" \
   -@com_google_absl//absl/time/internal/cctz:time_zone_format_test

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -15,6 +15,20 @@
 
 set -euo pipefail
 
+# Detect platform for toolchain label suffix.
+_host_os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+_host_arch="$(uname -m)"
+if [[ "${_host_arch}" == "x86_64" ]]; then
+  _host_arch="x86_64"
+elif [[ "${_host_arch}" == "aarch64" ]] || [[ "${_host_arch}" == "arm64" ]]; then
+  _host_arch="aarch64"
+fi
+if [[ "${_host_os}" == "darwin" ]]; then
+  _toolchain_suffix="${_host_arch}-darwin"
+else
+  _toolchain_suffix="${_host_arch}-linux"
+fi
+
 # Select the toolchain based on TEST_STDLIB (set by CI matrix).
 # "default" uses the registered llvm_toolchain (builtin-libc++).
 # "libc++", "stdc++", and "dynamic-stdc++" use the corresponding toolchains.
@@ -23,13 +37,13 @@ default)
   toolchain_name=""
   ;;
 libc++)
-  toolchain_name="@llvm_toolchain_libcxx//:cc-toolchain-x86_64-linux"
+  toolchain_name="@llvm_toolchain_libcxx//:cc-toolchain-${_toolchain_suffix}"
   ;;
 stdc++)
-  toolchain_name="@llvm_toolchain_stdcpp//:cc-toolchain-x86_64-linux"
+  toolchain_name="@llvm_toolchain_stdcpp//:cc-toolchain-${_toolchain_suffix}"
   ;;
 dynamic-stdc++)
-  toolchain_name="@llvm_toolchain_dynamic_stdcpp//:cc-toolchain-x86_64-linux"
+  toolchain_name="@llvm_toolchain_dynamic_stdcpp//:cc-toolchain-${_toolchain_suffix}"
   ;;
 *)
   echo >&2 "Unknown TEST_STDLIB: ${TEST_STDLIB}"
@@ -52,7 +66,10 @@ if [[ -n "${toolchain_name}" ]]; then
 fi
 
 # Extra test targets (e.g. rules_rust) that require bazel >= 9 and bzlmod.
-targets=()
+targets=(
+  //foreign:pcre
+  @boringssl//...
+)
 
 # rules_rust bzlmod support is unreliable on older Bazel versions;
 # only run rust-related prep and tests on bazel 9+ with bzlmod enabled.
@@ -79,13 +96,13 @@ if [[ "${_use_bazel_version}" != "8."* ]] && [[ "${USE_BZLMOD:-true}" == "true" 
   echo "------------------------------------------------------"
 
   targets+=(
-    "@rules_rust//test/unit/{interleaved_cc_info,native_deps}:all"
+    @rules_rust//test/unit/{interleaved_cc_info,native_deps}:all
     "@io_bazel_rules_go//tests/core/cgo:all"
     "-@io_bazel_rules_go//tests/core/cgo:cc_libs_test"
     "-@io_bazel_rules_go//tests/core/cgo:cgo_abs_paths_test"
     "-@io_bazel_rules_go//tests/core/cgo:external_includes_test"
     "-@io_bazel_rules_go//tests/core/cgo:wrapped_cgo_test"
-    "-@rules_rust//test/unit/native_deps:{cdylib,bin}_has_native_dep_and_alwayslink_{cc,rust}_linker_test"
+    -@rules_rust//test/unit/native_deps:{cdylib,bin}_has_native_dep_and_alwayslink_{cc,rust}_linker_test
   )
 fi
 
@@ -119,7 +136,4 @@ echo "Bazel test args: ${test_args[*]}"
 targets+=($("${bazel}" query "${common_args[@]}" 'attr(timeout, short, tests(@com_google_absl//absl/...) except attr(tags, benchmark, tests(@com_google_absl//absl/...)))'))
 targets+=("-@com_google_absl//absl/time/internal/cctz:time_zone_format_test")
 
-"${bazel}" --bazelrc=/dev/null test "${test_args[@]}" -- \
-  //foreign:pcre \
-  @boringssl//... \
-  "${targets[@]}"
+"${bazel}" --bazelrc=/dev/null test "${test_args[@]}" -- "${targets[@]}"

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -73,8 +73,8 @@ if [[ "${_use_bazel_version}" != "8."* ]] && [[ "${USE_BZLMOD:-true}" == "true" 
   else
     generate_imported_dylib_sh="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
   fi
-  echo "Script: '${generate_imported_dylib_sh}'"
   echo "------------------------------------------------------"
+  echo "Script: '${generate_imported_dylib_sh}'"
   "${generate_imported_dylib_sh}" "${IMPORTED_C_PATH-}" "${OUTPUT_DIR:-${output_base}}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
   echo "------------------------------------------------------"
 
@@ -116,10 +116,10 @@ echo "Bazel test args: ${test_args[*]}"
 # - time_zone_format_test from abseil-cpp because it assumes TZ is set to America/Los_Angeles, but
 #   we run the tests in UTC.
 # shellcheck disable=SC2207
-absl_targets=($("${bazel}" query "${common_args[@]}" 'attr(timeout, short, tests(@com_google_absl//absl/...) except attr(tags, benchmark, tests(@com_google_absl//absl/...)))'))
+targets+=($("${bazel}" query "${common_args[@]}" 'attr(timeout, short, tests(@com_google_absl//absl/...) except attr(tags, benchmark, tests(@com_google_absl//absl/...)))'))
+targets+=("-@com_google_absl//absl/time/internal/cctz:time_zone_format_test")
+
 "${bazel}" --bazelrc=/dev/null test "${test_args[@]}" -- \
   //foreign:pcre \
   @boringssl//... \
-  "${targets[@]}" \
-  "${absl_targets[@]}" \
-  -@com_google_absl//absl/time/internal/cctz:time_zone_format_test
+  "${targets[@]}"

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -15,6 +15,28 @@
 
 set -euo pipefail
 
+# Select the toolchain based on TEST_STDLIB (set by CI matrix).
+# "default" uses the registered llvm_toolchain (builtin-libc++).
+# "libc++", "stdc++", and "dynamic-stdc++" use the corresponding toolchains.
+case "${TEST_STDLIB:-default}" in
+default)
+  toolchain_name=""
+  ;;
+libc++)
+  toolchain_name="@llvm_toolchain_libcxx//:cc-toolchain-x86_64-linux"
+  ;;
+stdc++)
+  toolchain_name="@llvm_toolchain_stdcpp//:cc-toolchain-x86_64-linux"
+  ;;
+dynamic-stdc++)
+  toolchain_name="@llvm_toolchain_dynamic_stdcpp//:cc-toolchain-x86_64-linux"
+  ;;
+*)
+  echo >&2 "Unknown TEST_STDLIB: ${TEST_STDLIB}"
+  exit 1
+  ;;
+esac
+
 scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 # shellcheck source=./tests/scripts/bazel.sh
@@ -25,6 +47,10 @@ cd "${scripts_dir}"
 
 # Generate some files needed for the tests.
 echo "Bazel common args: ${common_args[*]}"
+if [[ -n "${toolchain_name}" ]]; then
+  common_test_args+=("--extra_toolchains=${toolchain_name}")
+fi
+
 "${bazel}" query "${common_args[@]}" @io_bazel_rules_go//tests/core/cgo:dylib_test >/dev/null
 
 output_base="$("${bazel}" info output_base)"


### PR DESCRIPTION
## Summary

Extend `external_test` in `.github/workflows/tests.yml` to cover all supported stdlib implementations by adding a `stdlib` matrix dimension and corresponding test toolchains.

## What changed

### CI matrix (`.github/workflows/tests.yml`)

The `external_test` job now includes a `stdlib` dimension with four values:

| stdlib | behaviour |
|---|---|
| `default` | No override — auto-config picks `builtin-libc++` |
| `libc++` | System/sysroot-hosted libc++ |
| `stdc++` | Static libstdc++ |
| `dynamic-stdc++` | Dynamic libstdc++ |

**Exclusions to keep the matrix manageable:**

- **macOS + non-default stdlib** — libstdc++ is not available on macOS by default (would need homebrew install)
- **bzlmod=false + non-default stdlib** — only test the default `builtin-libc++` in legacy mode
- **bazel latest + bzlmod=false** — not needed

**Bazel versions:** restricted to `8.*` and `latest` (the old "rules_rust bzlmod support is experimental" comment from 2023 is stale).

### Test toolchains (`tests/MODULE.bazel` + `tests/WORKSPACE`)

Three new toolchain configurations added to both bzlmod and WORKSPACE modes:

- `llvm_toolchain_libcxx` — `stdlib = "libc++"`
- `llvm_toolchain_stdcpp` — `stdlib = "stdc++"`
- `llvm_toolchain_dynamic_stdcpp` — `stdlib = "dynamic-stdc++"`

### Test script (`tests/scripts/run_external_tests.sh`)

- **Platform detection** — uses `uname` to auto-detect the correct toolchain label suffix (`aarch64-darwin`, `x86_64-linux`, etc.) instead of hardcoding `x86_64-linux`
- **`TEST_STDLIB` env var** — selects which extra toolchain to pass via `--extra_toolchains`
- **`targets` array** — all test targets collected into a single array, passed as one `-- "${targets[@]}"` argument to `bazel test`
- **Conditional rust/go tests** — rules_rust and rules_go cgo prep+targets only run on bazel 9+ with bzlmod enabled (rules_rust bzlmod support is unreliable on older Bazel versions)

### WORKSPACE boringssl fix

Added missing `patch_args` and `patches` attributes to the boringssl `http_archive` in `tests/WORKSPACE` to match the bzlmod version in `tests/MODULE.bazel`.