### PR TITLE
Upgrade trunk plugins to v1.9.0 for macOS shellcheck fix

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -4,7 +4,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.8.0
+      ref: v1.9.0
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
@@ -59,7 +59,7 @@ lint:
   enabled:
     - actionlint@1.7.12
     - buildifier@8.5.1
-    - checkov@3.2.526
+    - checkov@3.2.527
     - git-diff-check
     - markdownlint@0.48.0
     - prettier@3.8.3
@@ -68,6 +68,8 @@ lint:
     - trivy@0.70.0
     - trufflehog@3.95.2
     - yamllint@1.38.0
+  disabled:
+    - renovate
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
This upgrade addresses the issue where shellcheck required Rosetta on macOS.
The v1.9.0 release includes fixes for native macOS support.

Changes:
- Upgraded trunk plugins from v1.8.0 to v1.9.0
- Upgraded checkov from 3.2.526 to 3.2.527
- Disabled renovate linter

See: https://github.com/trunk-io/plugins/releases/tag/v1.9.0