### PR TITLE
Apply the path-prefix slash convention to sysroot_path

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -318,6 +318,13 @@ def cc_toolchain_config(
     conly_flags = compiler_configuration["conly_flags"]
     sysroot_path = compiler_configuration["sysroot_path"]
 
+    # Follow the same convention as the `*_path_prefix` arguments: a non-empty
+    # sysroot path is a canonical directory path ending in '/', concatenated
+    # with relative subpaths (no leading slash). Error out rather than silently
+    # producing malformed flags.
+    if sysroot_path and not sysroot_path.endswith("/"):
+        fail("sysroot_path must end with '/', got: {}".format(repr(sysroot_path)))
+
     # Flags related to C++ standard.
     cxx_flags = [
         "-std=" + cxx_standard,
@@ -368,7 +375,7 @@ def cc_toolchain_config(
             # redundant and its dylib causes the runtime failure described
             # above, so the libunwind config flag has no effect on macOS.
             link_flags.extend([
-                "-L{}/usr/lib".format(sysroot_path),
+                "-L{}usr/lib".format(sysroot_path),
                 "-lc++",
                 "-lc++abi",
                 "-Bdynamic",
@@ -438,11 +445,11 @@ def cc_toolchain_config(
             cxx_flags.extend([
                 "-nostdinc++",
                 "-cxx-isystem",
-                sysroot_path + "/usr/include/c++/" + libstdcxx_version,
+                sysroot_path + "usr/include/c++/" + libstdcxx_version,
                 "-cxx-isystem",
-                sysroot_path + "/usr/include/" + multiarch + "/c++/" + libstdcxx_version,
+                sysroot_path + "usr/include/" + multiarch + "/c++/" + libstdcxx_version,
                 "-cxx-isystem",
-                sysroot_path + "/usr/include/c++/" + libstdcxx_version + "/backward",
+                sysroot_path + "usr/include/c++/" + libstdcxx_version + "/backward",
             ])
 
             # Clang really wants C system header includes after C++ ones.
@@ -453,7 +460,7 @@ def cc_toolchain_config(
             ])
 
             link_flags.extend([
-                "-L" + sysroot_path + "/usr/lib/gcc/" + multiarch + "/" + libstdcxx_version,
+                "-L" + sysroot_path + "usr/lib/gcc/" + multiarch + "/" + libstdcxx_version,
             ])
         else:
             fail("Invalid stdlib: " + stdlib)

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -86,7 +86,7 @@ def _detect_gcc_cxx_headers(rctx, sysroot_path, target_system_name):
 
     # Check for GCC C++ headers in common locations
     # Modern distros (Debian 10+, Ubuntu 18.04+): /usr/include/c++/<version>
-    cxx_include_path = rctx.path(sysroot_path + "/usr/include/c++")
+    cxx_include_path = rctx.path(sysroot_path + "usr/include/c++")
     if cxx_include_path.exists:
         # Find GCC version directories (e.g., "14", "13", "12")
         for entry in cxx_include_path.readdir():
@@ -103,7 +103,7 @@ def _detect_gcc_cxx_headers(rctx, sysroot_path, target_system_name):
 
     # Also check traditional GCC installation path: /usr/lib/gcc/<triple>/<version>/...
     # This is the layout used by older distros and Chromium sysroots
-    gcc_lib_path = rctx.path(sysroot_path + "/usr/lib/gcc/" + gnu_triple)
+    gcc_lib_path = rctx.path(sysroot_path + "usr/lib/gcc/" + gnu_triple)
     if gcc_lib_path.exists:
         for entry in gcc_lib_path.readdir():
             version = entry.basename
@@ -442,6 +442,13 @@ def _cc_toolchain_str(
             # We are trying to cross-compile without a sysroot, let's bail.
             # TODO: Are there other situations where we can continue?
             return ""
+
+    # Normalize the sysroot to a canonical directory path ending in "/", the
+    # same convention used by the `*_path_prefix` arguments. cc_toolchain_config
+    # concatenates relative subpaths (no leading slash) and asserts the
+    # convention, rather than silently producing malformed flags.
+    if sysroot_path:
+        sysroot_path = _canonical_dir_path(sysroot_path)
 
     extra_files_str = repr(":internal-use-tools" if bazel_features.rules.merkle_cache_v2 else ":internal-use-tools-legacy")
 


### PR DESCRIPTION
The `*_path_prefix` arguments are required to end in "/" (asserted in cc_toolchain_config) and are concatenated with relative subpaths, e.g. `"{}lib/clang/...".format(prefix)`. `sysroot_path` did not follow this convention: it was never canonicalized, and usages were inconsistent -- some prepended a leading slash (`sysroot_path + "/usr/..."`) while the external_include_paths block did not (`sysroot_path + "usr/..."`). For an absolute sysroot without a trailing slash this produces a malformed path in the no-leading-slash sites; for a label/canonical sysroot (trailing slash) it produces a double slash in the leading-slash sites.

Make sysroot_path follow the same model:
- configure.bzl canonicalizes it to a directory path ending in "/".
- cc_toolchain_config.bzl asserts the trailing slash and concatenates relative subpaths everywhere (no leading slash).