### PR TITLE
Add per-target extra_compiler_files and extra_linker_files bzlmod tags

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -53,6 +53,30 @@ build_test(
     ],
 )
 
+build_test(
+    name = "extra_files_extension_test",
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+    targets = [
+        "@llvm_toolchain//:all-files-x86_64-linux",
+    ],
+)
+
+# Verifies that extra_compiler_files actually makes the file available in the
+# compile action sandbox. Uses -fsanitize-ignorelist pointing at the provisioned
+# file; clang errors at compile time if the file is absent from the sandbox.
+cc_test(
+    name = "extra_files_compile_test",
+    srcs = ["stdlib_test.cc"],
+    copts = ["-fsanitize-ignorelist=$(execpath //extra_files:all_files)"],
+    data = ["//extra_files:all_files"],
+    linkstatic = True,
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [":stdlib"],
+)
+
 # We want to test that `llvm-dwp` (used when assembling a `.dwp` file from
 # `.dwo` files) can be called.
 #

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -79,6 +79,14 @@ llvm.extra_target_compatible_with(
     name = "llvm_toolchain",
     constraints = ["@//:cxx17"],
 )
+llvm.extra_compiler_files(
+    name = "llvm_toolchain",
+    label = "//extra_files:all_files",
+)
+llvm.extra_linker_files(
+    name = "llvm_toolchain",
+    label = "//extra_files:all_files",
+)
 use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
 
 register_toolchains("@llvm_toolchain//:all")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -78,6 +78,8 @@ LLVM_VERSIONS = {
 llvm_toolchain(
     name = "llvm_toolchain",
     cxx_standard = {"": "c++17"},
+    extra_compiler_files = "//extra_files:all_files",
+    extra_linker_files = "//extra_files:all_files",
     extra_target_compatible_with = {
         "": ["@//:cxx17"],
     },

--- a/tests/extra_files/BUILD.bazel
+++ b/tests/extra_files/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "all_files",
+    srcs = ["ignorelist.txt"],
+    visibility = ["//visibility:public"],
+)

--- a/tests/extra_files/ignorelist.txt
+++ b/tests/extra_files/ignorelist.txt
@@ -1,0 +1,1 @@
+# Sanitizer ignorelist — used to verify extra_compiler_files reach the compile sandbox.

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -68,6 +68,11 @@ targets=(
 # toolchain won't work so :test_cxx_standard_is_20 won't build.
 if [[ -z "${toolchain_name}" ]]; then
   targets+=("//:test_cxx_standard_is_20")
+  # :extra_files_compile_test depends on extra_compiler_files on @llvm_toolchain;
+  # restricted to linux because the cc_test target uses linux-only constraints.
+  if [[ ${OSTYPE} == 'linux'* ]]; then
+    targets+=("//:extra_files_compile_test")
+  fi
 fi
 
 if [[ -n "${enable_omp_targets}" ]]; then

--- a/toolchain/extensions/llvm.bzl
+++ b/toolchain/extensions/llvm.bzl
@@ -21,12 +21,13 @@ def _root_dict(roots, cls, name, strip_target):
         for target in targets:
             if res.get(target):
                 fail("duplicate target '%s' found for %s with name '%s'" % (target, cls, name))
-            if bool(root.path) == (root.label):
+            path = getattr(root, "path", "")
+            if bool(path) == bool(root.label):
                 fail("target '%s' for %s with name '%s' must have either path or label, but not both" % (target, cls, name))
-            if root.path:
-                if not _is_absolute_path(root.path):
+            if path:
+                if not _is_absolute_path(path):
                     fail("target '%s' for %s with name '%s' must have an absolute path value" % (target, cls, name))
-                res.update([(target, root.path)])
+                res.update([(target, path)])
                 continue
             label_str = str(root.label)
             if strip_target:
@@ -64,6 +65,8 @@ def _llvm_impl_(module_ctx):
             }
             attrs["toolchain_roots"] = _root_dict([root for root in mod.tags.toolchain_root if root.name == name], "toolchain_root", name, True)
             attrs["sysroot"] = _root_dict([sysroot for sysroot in mod.tags.sysroot if sysroot.name == name], "sysroot", name, False)
+            attrs["extra_compiler_files_dict"] = _root_dict([tag for tag in mod.tags.extra_compiler_files if tag.name == name], "extra_compiler_files", name, False)
+            attrs["extra_linker_files_dict"] = _root_dict([tag for tag in mod.tags.extra_linker_files if tag.name == name], "extra_linker_files", name, False)
             attrs["extra_exec_compatible_with"] = _constraint_dict(
                 [tag for tag in mod.tags.extra_exec_compatible_with if tag.name == name],
                 name,
@@ -84,6 +87,12 @@ def _llvm_impl_(module_ctx):
         for root in mod.tags.sysroot:
             if root.name not in toolchain_names:
                 fail("sysroot '%s' does not have a corresponding toolchain" % root.name)
+        for tag in mod.tags.extra_compiler_files:
+            if tag.name not in toolchain_names:
+                fail("extra_compiler_files '%s' does not have a corresponding toolchain" % tag.name)
+        for tag in mod.tags.extra_linker_files:
+            if tag.name not in toolchain_names:
+                fail("extra_linker_files '%s' does not have a corresponding toolchain" % tag.name)
 
     if bazel_features.external_deps.extension_metadata_has_reproducible:
         return module_ctx.extension_metadata(reproducible = True)
@@ -100,6 +109,8 @@ _attrs.update(_llvm_repo_attrs)
 
 _attrs.pop("toolchain_roots", None)
 _attrs.pop("sysroot", None)
+_attrs.pop("extra_compiler_files_dict", None)
+_attrs.pop("extra_linker_files_dict", None)
 
 llvm = module_extension(
     implementation = _llvm_impl_,
@@ -121,6 +132,20 @@ llvm = module_extension(
                 "targets": attr.string_list(doc = "Specific targets, if any; empty list means this applies to all."),
                 "label": attr.label(doc = "Label containing the files with its package path as the sysroot path."),
                 "path": attr.string(doc = "Absolute path to the sysroot."),
+            },
+        ),
+        "extra_compiler_files": tag_class(
+            attrs = {
+                "name": attr.string(doc = "Same name as the toolchain tag.", default = "llvm_toolchain"),
+                "targets": attr.string_list(doc = "Specific targets, if any; empty list means this applies to all."),
+                "label": attr.label(doc = "Label containing files to be made available in the sandbox for compile actions."),
+            },
+        ),
+        "extra_linker_files": tag_class(
+            attrs = {
+                "name": attr.string(doc = "Same name as the toolchain tag.", default = "llvm_toolchain"),
+                "targets": attr.string_list(doc = "Specific targets, if any; empty list means this applies to all."),
+                "label": attr.label(doc = "Label containing files to be made available in the sandbox for link actions."),
             },
         ),
         "extra_exec_compatible_with": tag_class(

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -290,6 +290,8 @@ def llvm_config_impl(rctx):
         llvm_version = llvm_version,
         extra_compiler_files = rctx.attr.extra_compiler_files,
         extra_linker_files = rctx.attr.extra_linker_files,
+        extra_compiler_files_dict = rctx.attr.extra_compiler_files_dict,
+        extra_linker_files_dict = rctx.attr.extra_linker_files_dict,
         extra_exec_compatible_with = rctx.attr.extra_exec_compatible_with,
         extra_target_compatible_with = rctx.attr.extra_target_compatible_with,
         extra_compile_flags_dict = rctx.attr.extra_compile_flags,
@@ -431,6 +433,17 @@ def _cc_toolchain_str(
         sysroot_label_str = repr(str(sysroot_label))
     else:
         sysroot_label_str = ""
+
+    _extra_compiler_label = (
+        toolchain_info.extra_compiler_files_dict.get(target_pair) or
+        toolchain_info.extra_compiler_files_dict.get("") or
+        (str(toolchain_info.extra_compiler_files) if toolchain_info.extra_compiler_files else None)
+    )
+    _extra_linker_label = (
+        toolchain_info.extra_linker_files_dict.get(target_pair) or
+        toolchain_info.extra_linker_files_dict.get("") or
+        (str(toolchain_info.extra_linker_files) if toolchain_info.extra_linker_files else None)
+    )
 
     if not sysroot_path:
         if exec_os == target_os and exec_arch == target_arch:
@@ -796,9 +809,9 @@ cc_toolchain(
         cxx_builtin_include_directories = _list_to_string(filtered_cxx_builtin_include_directories),
         cxx_builtin_include_label = "cxx_builtin_include" if bazel_features.rules.merkle_cache_v2 else "include",
         lib_label = "lib" if bazel_features.rules.merkle_cache_v2 else "lib_legacy",
-        extra_compiler_files = ("\"%s\"," % str(toolchain_info.extra_compiler_files)) if toolchain_info.extra_compiler_files else "",
+        extra_compiler_files = ("\"%s\"," % _extra_compiler_label) if _extra_compiler_label else "",
         llvm_version = llvm_version,
-        extra_linker_files = ("\"%s\"," % str(toolchain_info.extra_linker_files)) if toolchain_info.extra_linker_files else "",
+        extra_linker_files = ("\"%s\"," % _extra_linker_label) if _extra_linker_label else "",
         extra_exec_compatible_with_specific = toolchain_info.extra_exec_compatible_with.get(target_pair, []),
         extra_target_compatible_with_specific = toolchain_info.extra_target_compatible_with.get(target_pair, []),
         extra_exec_compatible_with_all_targets = toolchain_info.extra_exec_compatible_with.get("", []),

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -373,6 +373,18 @@ _compiler_configuration_attrs = {
         doc = ("Files to be made available in the sandbox for link actions. " +
                "Useful for providing files such as linker scripts."),
     ),
+    "extra_compiler_files_dict": attr.string_dict(
+        mandatory = False,
+        doc = ("Per-target files to be made available in the sandbox for compile actions. " +
+               "Keys are target OS-arch pairs (e.g. 'linux-x86_64') or empty string for all targets. " +
+               "Values are label strings. Intended for use via the bzlmod `llvm.extra_compiler_files` tag."),
+    ),
+    "extra_linker_files_dict": attr.string_dict(
+        mandatory = False,
+        doc = ("Per-target files to be made available in the sandbox for link actions. " +
+               "Keys are target OS-arch pairs (e.g. 'linux-x86_64') or empty string for all targets. " +
+               "Values are label strings. Intended for use via the bzlmod `llvm.extra_linker_files` tag."),
+    ),
     "extra_enabled_features": attr.label_list(
         mandatory = False,
         doc = ("Extra `cc_feature` features to add to this toolchain in an initially " +


### PR DESCRIPTION
Adds llvm.extra_compiler_files and llvm.extra_linker_files tag classes to the bzlmod extension, following the same pattern as llvm.sysroot. Both tags accept a label and optional targets list, allowing per-target files to be made available in the toolchain's sandbox filegroups for compile and link actions respectively.

The existing single-label extra_compiler_files and extra_linker_files attrs on the WORKSPACE llvm_toolchain rule are unchanged.