### PR TITLE
Include extra_compiler_files in cxx_builtin_include_files

### DIFF
--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -678,7 +678,10 @@ filegroup(name = "strip-files-{suffix}", srcs = [{extra_files_str}])
         template = template + """
 filegroup(
     name = "cxx_builtin_include_files-{suffix}",
-    srcs = ["{target_toolchain_root}:{cxx_builtin_include_label}"],
+    srcs = [
+        "{target_toolchain_root}:{cxx_builtin_include_label}",
+        {extra_compiler_files}
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
Headers injected via the `extra_compiler_files` attribute are added to the compiler inputs but, in the non-absolute-path toolchain layout, they were not part of cxx_builtin_include_files. As a result they were absent from the generated system module map, so a build with layering_check / -fmodules-strict-decluse rejects them as not covered by any module.

Add `{extra_compiler_files}` to the cxx_builtin_include_files-{suffix} filegroup (matching how it is already included in compiler-components) so any extra compiler headers under a builtin include directory are covered by the system module map.