### PR TITLE
Redact date macros via -imacros header instead of -D on command line

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -41,6 +41,7 @@ def cc_toolchain_config(
         target_toolchain_path_prefix,
         tools_path_prefix,
         wrapper_bin_prefix,
+        redacted_dates_path,
         compiler_configuration,
         cxx_builtin_include_directories,
         extra_known_features,
@@ -190,11 +191,12 @@ def cc_toolchain_config(
     unfiltered_compile_flags = [
         # Do not resolve our symlinked resource prefixes to real paths.
         "-no-canonical-prefixes",
-        # Reproducibility
+        # Reproducibility: redact date macros via an -imacros header rather than
+        # -D__DATE__="redacted" on the command line, whose quotes are lost when
+        # passed through sub-build flag strings.
         "-Wno-builtin-macro-redefined",
-        "-D__DATE__=\"redacted\"",
-        "-D__TIMESTAMP__=\"redacted\"",
-        "-D__TIME__=\"redacted\"",
+        "-imacros",
+        redacted_dates_path,
     ]
 
     major_llvm_version = int(llvm_version.split(".")[0])

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -359,6 +359,13 @@ def llvm_config_impl(rctx):
         },
     )
 
+    rctx.file(
+        "redacted_dates.h",
+        "#define __DATE__      \"redacted\"\n" +
+        "#define __TIME__      \"redacted\"\n" +
+        "#define __TIMESTAMP__ \"redacted\"\n",
+    )
+
     if hasattr(rctx, "repo_metadata"):
         return rctx.repo_metadata(reproducible = True)
     else:
@@ -576,6 +583,7 @@ cc_toolchain_config(
     target_toolchain_path_prefix = "{target_toolchain_path_prefix}",
     tools_path_prefix = "{tools_path_prefix}",
     wrapper_bin_prefix = "{wrapper_bin_prefix}",
+    redacted_dates_path = "{redacted_dates_path}",
     compiler_configuration = {{
       "sysroot_path": "{sysroot_path}",
       "stdlib": "{stdlib}",
@@ -645,6 +653,7 @@ filegroup(
     name = "compiler-components-{suffix}",
     srcs = [
         ":sysroot-components-{suffix}",
+        "redacted_dates.h",
         {extra_compiler_files}
     ],
 )
@@ -688,6 +697,7 @@ filegroup(
         ":sysroot-components-{suffix}",
         "{llvm_dist_label_prefix}extra_config_site",
         "{toolchain_root}:clang",
+        "redacted_dates.h",
         {extra_compiler_files}
     ],
 )
@@ -728,6 +738,7 @@ system_module_map(
     name = "module-{suffix}",
     cxx_builtin_include_files = ":cxx_builtin_include_files-{suffix}",
     cxx_builtin_include_directories = {cxx_builtin_include_directories},
+    extra_textual_headers = "redacted_dates.h",
     sysroot_files = ":sysroot-components-{suffix}",
     sysroot_path = "{sysroot_path}",
 )
@@ -775,6 +786,7 @@ cc_toolchain(
         target_toolchain_path_prefix = target_toolchain_path_prefix,
         tools_path_prefix = toolchain_info.tools_path_prefix,
         wrapper_bin_prefix = toolchain_info.wrapper_bin_prefix,
+        redacted_dates_path = "external/{}/redacted_dates.h".format(rctx.name),
         sysroot_label_str = sysroot_label_str,
         sysroot_path = sysroot_path,
         stdlib = stdlib,

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -60,7 +60,26 @@ def _system_module_map(ctx):
         execroot_prefix + paths.normalize(file.path).replace("//", "/"),
     )
 
+    # Unlike cxx_builtin_include_files, whose entries are source directories
+    # emitted as umbrella submodules, these are individual headers (e.g. a
+    # force-included header) that must always be emitted as textual headers.
+    forced_textual_header_closure = lambda file: "  textual header \"{}{}\"".format(
+        execroot_prefix,
+        paths.normalize(file.path).replace("//", "/"),
+    )
+
     template_dict = ctx.actions.template_dict()
+
+    if ctx.attr.extra_textual_headers:
+        template_dict.add_joined(
+            "%extra_textual_headers%",
+            ctx.attr.extra_textual_headers[DefaultInfo].files,
+            join_with = "\n",
+            map_each = forced_textual_header_closure,
+            allow_closure = True,
+        )
+    else:
+        template_dict.add("%extra_textual_headers%", "")
 
     if bazel_features.rules.merkle_cache_v2:
         # If provided, cxx_builtin_files should be a filegroup with 2 source directory entries:
@@ -121,6 +140,7 @@ system_module_map = rule(
     attrs = {
         "cxx_builtin_include_files": attr.label(mandatory = True),
         "cxx_builtin_include_directories": attr.string_list(mandatory = True),
+        "extra_textual_headers": attr.label(allow_files = True),
         "sysroot_files": attr.label(),
         "sysroot_path": attr.string(),
         "_module_map_template": attr.label(

--- a/toolchain/internal/template.modulemap
+++ b/toolchain/internal/template.modulemap
@@ -1,5 +1,6 @@
 module "crosstool" [system] {
 %cxx_builtin_include_files%
+%extra_textual_headers%
 %sysroot%
 %umbrella_submodules%
 }


### PR DESCRIPTION
Reproducibility redaction of __DATE__/__TIME__/__TIMESTAMP__ was done with
-D__DATE__="redacted" etc. in unfiltered_compile_flags. The surrounding quotes
are required (the value is a string literal), but they do not survive being
passed through sub-build flag strings: tools that re-serialize the toolchain's
compile flags into their own build scripts (rules_foreign_cc make/cmake builds,
embedded compiler-flag strings) drop the quotes, leaving a bare `redacted`
token that the compiler treats as an identifier and fails on.

Write the three #define directives into a generated redacted_dates.h and
force-include it with `-imacros`, so no quoting has to survive the command
line.

Because layering_check requires every included header to be covered by a
module, the force-included header must appear in the generated system module
map. Add an `extra_textual_headers` input to system_module_map for individual
headers that must always be emitted as `textual header` entries -- unlike
cxx_builtin_include_files, whose entries are source directories emitted as
umbrella submodules (which cannot cover a single file). redacted_dates.h is
routed through this new input.