### PR TITLE
ci: aggregate required checks into a single required_checks_done gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,3 +160,47 @@ jobs:
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux -v 16.0.0
+  # Single aggregating gate for branch protection. It depends on every job that
+  # must pass, so "required_checks_done" is the only status check that needs to
+  # be marked "required" on the master branch -- adding or renaming a job above
+  # no longer means editing branch protection, only this job's `needs` list.
+  # When any dependency fails or is cancelled, this job fails and names the
+  # offending jobs in its log and in the run summary.
+  required_checks_done:
+    name: required_checks_done
+    needs:
+      - lint
+      - test
+      - toolchain_test
+      - external_test
+      - container_test
+      - xcompile_test
+      - abs_paths_test
+      - sys_paths_test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          {
+            echo "| Required job | Result |"
+            echo "| --- | --- |"
+            jq -r 'to_entries[] | "| \(.key) | \(.value.result) |"' <<<"${NEEDS_JSON}"
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+          failed="$(jq -r 'to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | .key' <<<"${NEEDS_JSON}")"
+
+          if [[ -n "${failed}" ]]; then
+            echo "The following required jobs did not succeed:"
+            while read -r job; do
+              echo "  - ${job}"
+              echo "::error title=Required job failed::${job} did not succeed"
+            done <<<"${failed}"
+            exit 1
+          fi
+
+          echo "All required jobs succeeded."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,27 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+      - name: Ensure every job is wired into this gate
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          # Parse the workflow with a real YAML reader (yq) and fail if any
+          # declared job (other than this gate) is absent from `needs` above, so
+          # a newly added job cannot silently escape the required gate.
+          declared="$(yq '.jobs | keys | .[]' .github/workflows/tests.yml |
+            grep -vx required_checks_done | sort)"
+          wired="$(jq -r 'keys[]' <<<"${NEEDS_JSON}" | sort)"
+          missing="$(comm -23 <(printf '%s\n' "${declared}") <(printf '%s\n' "${wired}"))"
+          if [[ -n "${missing}" ]]; then
+            echo "Jobs declared in the workflow but missing from required_checks_done.needs:"
+            while read -r job; do
+              echo "  - ${job}"
+              echo "::error title=Gate is missing a job::${job} not in required_checks_done.needs"
+            done <<<"${missing}"
+            exit 1
+          fi
+          echo "required_checks_done covers all $(grep -c . <<<"${declared}") workflow jobs."
       - name: Verify required jobs succeeded
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}


### PR DESCRIPTION
## What

Adds a single `required_checks_done` job to the `Tests` workflow that `needs:` every test job and runs with `if: always()`. It fails (and names the offending jobs in its log and the run summary) whenever any dependency does not succeed.

## Why

Today branch protection has to list every individual job (`lint`, `test`, `toolchain_test`, `external_test`, `container_test`, `xcompile_test`, `abs_paths_test`, `sys_paths_test`) as a required status check. Adding, renaming, or removing a job means editing the branch protection settings too, and it's easy to forget.

With this aggregating gate, branch protection only needs to require **one** check — `required_checks_done`. Adding/renaming/removing a job now only means editing this job's `needs:` list.

## Behaviour

- `if: always()` so the gate still runs when a dependency fails or the run is cancelled (GitHub otherwise skips a `needs` job whose dependency failed).
- Reads `toJSON(needs)` via an env var (not interpolated into the script — avoids injection), writes a Job → Result table to the run summary, and:
  - treats `success`/`skipped` as passing (so a future conditionally-skipped job won't deadlock the gate),
  - fails on `failure`/`cancelled`, emitting a `::error::` annotation per offending job.

## Follow-up (repo settings)

After merge, update branch protection on `master` to require only `required_checks_done` and drop the individual job checks.