### PR TITLE
Add MemorySanitizer support; drive all sanitizers via Bazel features

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,6 +163,27 @@ jobs:
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux -v 16.0.0
+  msan_test:
+    # End-to-end MemorySanitizer test. Downloads a full clang + an
+    # instrumented-libc++ overlay and builds/runs an msan binary, exercising the
+    # instrumented-libc++ swap end to end. Linux/x86_64 and bzlmod only (the
+    # overlay toolchain is defined via bzlmod). The bazel-version matrix covers
+    # both filegroup layouts: <9 uses lib_legacy/include, 9+ uses
+    # lib/cxx_builtin_include (merkle_cache_v2).
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel_version: [7.*, 8.*, 9.*, latest]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: tests/scripts/ubuntu_install_libtinfo.sh
+      - run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
+          USE_BZLMOD: true
+        run: tests/scripts/run_msan_tests.sh
   # Single aggregating gate for branch protection. It depends on every job that
   # must pass, so "required_checks_done" is the only status check that needs to
   # be marked "required" on the master branch -- adding or renaming a job above
@@ -180,6 +201,7 @@ jobs:
       - xcompile_test
       - abs_paths_test
       - sys_paths_test
+      - msan_test
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -370,6 +370,70 @@ deps (also known as "depend on what you use") for `cc_*` rules. This feature
 can be enabled by enabling the `layering_check` feature on a per-target,
 per-package or global basis.
 
+### Sanitizers
+
+The toolchain can build with AddressSanitizer, UndefinedBehaviorSanitizer,
+ThreadSanitizer, or MemorySanitizer. Enable at most one at a time, via Bazel
+features:
+
+```sh
+bazel build //... --features=asan
+bazel build //... --features=ubsan
+bazel build //... --features=tsan
+bazel build //... --features=msan   # Linux only; see below
+```
+
+`asan`, `ubsan`, and `tsan` are rules_cc's stock sanitizer features and work
+with the regular standard library. Enabling sanitizers as features means Bazel
+resets them to `--host_features` in the exec configuration, so build tools stay
+uninstrumented. For finer-grained control, combine with
+`--copt=-fsanitize-ignorelist=...` (the provided file is made available to
+compile actions via the `extra_compiler_files` attribute).
+
+MemorySanitizer additionally swaps in an instrumented libc++ (see below).
+
+#### MemorySanitizer and the instrumented libc++
+
+MemorySanitizer is Linux-only and is enabled with `--features=msan`. A feature
+is used so Bazel resets it to `--host_features` in the exec configuration,
+keeping build tools uninstrumented.
+
+MemorySanitizer reports false positives unless the C++ standard library is also
+instrumented, so `msan` swaps the toolchain's libc++ for an instrumented build
+(headers under `libcxx-msan/include`, libraries under `libcxx-msan/lib`).
+There is no official prebuilt instrumented libc++; you must build one from the
+matching LLVM sources and point the distribution at it with the `libcxx_url`
+and `libcxx_sha256` attributes (`llvm`/`llvm_toolchain` rules, or the
+`llvm.toolchain` module extension tag):
+
+```python
+llvm(
+    name = "llvm_toolchain_llvm",
+    llvm_version = "20.1.0",
+    libcxx_url = "https://example.com/libcxx-msan-20.1.0-x86_64-linux-gnu.tar.zst",
+    libcxx_sha256 = "<sha256>",
+)
+```
+
+Build the instrumented libc++ following the [MemorySanitizer libc++
+how-to](https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo),
+e.g.:
+
+```sh
+cmake -GNinja <llvm-src>/runtimes \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+  -DLLVM_USE_SANITIZER=MemoryWithOrigins \
+  -DLLVM_ENABLE_PIC=ON \
+  -DCMAKE_INSTALL_PREFIX=<prefix>
+ninja && ninja install
+# Archive the resulting <prefix>/lib and <prefix>/include directories; that is
+# the layout extracted into libcxx-msan/. libunwind itself is too low-level to
+# instrument, so overwrite the instrumented libunwind.* with the uninstrumented
+# one from your clang distribution before archiving.
+```
+
 ## Distribution data and scripts
 
 The list of LLVM releases this toolchain knows about lives as JSONC data

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load(":transitions.bzl", "dwp_file", "transition_library_to_platform")
+load(":transitions.bzl", "dwp_file", "msan_flags_test", "sanitizer_test", "transition_library_to_platform")
 
 cc_library(
     name = "stdlib",
@@ -75,6 +75,58 @@ cc_test(
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [":stdlib"],
+)
+
+# Sanitizer support (rules_cc's stock asan/ubsan/tsan features, augmented by the
+# toolchain with the C++ sanitizer runtime). The transition enables a single
+# sanitizer via `--features` for the wrapped binary so the test runs regardless
+# of the global build flags. Restricted to Linux, where the toolchain ships the
+# sanitizer runtimes.
+sanitizer_test(
+    name = "asan_test",
+    src = ":stdlib_bin",
+    sanitizer = "asan",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+sanitizer_test(
+    name = "ubsan_test",
+    src = ":stdlib_bin",
+    sanitizer = "ubsan",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+sanitizer_test(
+    name = "tsan_test",
+    src = ":stdlib_bin",
+    sanitizer = "tsan",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# Analysis-only msan check: verifies the msan flags and instrumented-libc++
+# include path are wired into the compile action. Runs against the default
+# toolchain, so it does not need the instrumented libc++ overlay.
+msan_flags_test(
+    name = "msan_flags_test",
+    target_compatible_with = ["@platforms//os:linux"],
+    target_under_test = ":stdlib_bin",
+)
+
+# End-to-end msan test. Built and run with the instrumented-libc++ toolchain
+# (@llvm_toolchain_msan) and --features=msan by tests/scripts/run_msan_tests.sh
+# (the `msan` CI job). Tagged manual so the default `bazel test //...` does not
+# build it with a non-msan toolchain; the script targets it explicitly. This
+# links and runs an instrumented libc++, so it catches a non-instrumented
+# libc++ being linked under msan, which msan_flags_test (analysis only) cannot.
+cc_test(
+    name = "msan_libcxx_test",
+    srcs = ["msan_libcxx_test.cc"],
+    linkstatic = True,
+    tags = ["manual"],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 # We want to test that `llvm-dwp` (used when assembling a `.dwp` file from

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -82,10 +82,18 @@ cc_test(
 # sanitizer via `--features` for the wrapped binary so the test runs regardless
 # of the global build flags. Restricted to Linux, where the toolchain ships the
 # sanitizer runtimes.
+#
+# Tagged `manual` so the default `bazel test //...`/`//:all` does not pick them
+# up: the `container_test` job runs `//:all` against the pinned LLVM 13.0.0
+# toolchain, whose sanitizer runtimes are too old for modern glibc (the asan
+# dlsym alloc pool overflows: `asan_malloc_linux.cpp` CHECK on rolling-release
+# distros). tests/scripts/run_tests.sh lists them explicitly for the default
+# (modern) toolchain instead.
 sanitizer_test(
     name = "asan_test",
     src = ":stdlib_bin",
     sanitizer = "asan",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )
 
@@ -93,6 +101,7 @@ sanitizer_test(
     name = "ubsan_test",
     src = ":stdlib_bin",
     sanitizer = "ubsan",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )
 
@@ -100,6 +109,7 @@ sanitizer_test(
     name = "tsan_test",
     src = ":stdlib_bin",
     sanitizer = "tsan",
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )
 

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -104,6 +104,30 @@ use_repo(llvm, "llvm_toolchain_cxx20")
 
 register_toolchains("@llvm_toolchain_cxx20//:all")
 
+# MemorySanitizer end-to-end toolchain. Pinned to the exact LLVM build that the
+# instrumented libc++ overlay (libcxx_url) was compiled against, so the linked
+# libc++ is itself instrumented and ABI-compatible. Used only by the msan tests
+# via --extra_toolchains (see tests/scripts/run_msan_tests.sh); deliberately not
+# registered globally. Linux x86_64 only.
+MSAN_LLVM_VERSION = "21.1.8"
+
+MSAN_DISTRIBUTION = "clang+llvm-%s-x86_64-linux-gnu-ubuntu-22.04.tar.zst" % MSAN_LLVM_VERSION
+
+llvm.toolchain(
+    name = "llvm_toolchain_msan",
+    alternative_llvm_sources = [
+        "https://github.com/RealtimeRoboticsGroup/toolchains/releases/download/{llvm_version}/{basename}",
+    ],
+    distribution = MSAN_DISTRIBUTION,
+    extra_llvm_distributions = {
+        MSAN_DISTRIBUTION: "3e9ab559182f45143c36d761fcee6818935187a8f54354ecb043643b642769f0",
+    },
+    libcxx_sha256 = "56e33981bb71aba8704026534093f81ba9783cff0bf701681f1781d2ecb50a87",
+    libcxx_url = "https://github.com/RealtimeRoboticsGroup/toolchains/releases/download/%s/libcxx-msan-%s-x86_64-linux-gnu-ubuntu-22.04.tar.zst" % (MSAN_LLVM_VERSION, MSAN_LLVM_VERSION),
+    llvm_versions = {"": MSAN_LLVM_VERSION},
+)
+use_repo(llvm, "llvm_toolchain_msan")
+
 # Toolchain examples for testing different stdlib implementations on Linux.
 # These are used by run_external_tests.sh in CI to verify that the toolchain
 # works with system-hosted libc++ and libstdc++ instead of the builtin libc++.

--- a/tests/msan_libcxx_test.cc
+++ b/tests/msan_libcxx_test.cc
@@ -1,0 +1,53 @@
+// End-to-end MemorySanitizer test.
+//
+// This reproduces the use-of-uninitialized-value that MSan reports when the
+// linked libc++ is NOT itself instrumented (for example when the toolchain
+// links the base libc++.a instead of the msan-instrumented overlay): a
+// std::stringstream's internal precision field is left "uninitialized" from
+// MSan's point of view, so reading it back -- or branching on a value that
+// flowed through the stream -- is reported as use-of-uninitialized-value.
+//
+// Built and run with the msan toolchain (instrumented libc++ overlay) and
+// --features=msan by tests/scripts/run_msan_tests.sh. With a correctly
+// instrumented libc++ the program exits 0; otherwise MSan aborts and the test
+// fails.
+
+#include <cstdio>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <sstream>
+#include <string>
+
+static std::string Format(double value) {
+  std::stringstream ss;
+  ss << std::setprecision(std::numeric_limits<double>::digits10 + 2);
+  ss << value;
+  return ss.str();
+}
+
+int main() {
+  // Stack-allocated stream.
+  std::stringstream stack_ss;
+  stack_ss << std::setprecision(5);
+  const std::streamsize stack_precision = stack_ss.precision();
+
+  // Heap-allocated stream (mirrors googletest's Message, which is where this
+  // was originally observed).
+  auto heap_ss = std::make_unique<std::stringstream>();
+  *heap_ss << std::setprecision(7);
+  const std::streamsize heap_precision = heap_ss->precision();
+
+  const std::string formatted = Format(3.14159);
+
+  std::printf("stack=%d heap=%d formatted=%s\n",
+              static_cast<int>(stack_precision),
+              static_cast<int>(heap_precision), formatted.c_str());
+
+  // Branch on values that flowed through libc++; MSan reports here if any of
+  // them are (incorrectly) considered uninitialized.
+  if (stack_precision != 5 || heap_precision != 7 || formatted.empty()) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/scripts/run_msan_tests.sh
+++ b/tests/scripts/run_msan_tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2024 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# End-to-end MemorySanitizer test. Builds and runs //:msan_libcxx_test with the
+# instrumented-libc++ toolchain (@llvm_toolchain_msan, configured via the
+# `libcxx_url` attribute in tests/MODULE.bazel) and `--features=msan`. This
+# links and runs an instrumented libc++, so it catches an uninstrumented libc++
+# being linked under msan -- something the analysis-only msan_flags_test cannot.
+#
+# msan is Linux/x86_64 only and the toolchain is defined via bzlmod, so this is
+# only run with USE_BZLMOD=true.
+
+set -euo pipefail
+
+while getopts "h" opt; do
+  case "${opt}" in
+  "h")
+    echo "Usage: No options"
+    exit 2
+    ;;
+  *)
+    echo "invalid option: -${OPTARG}"
+    exit 1
+    ;;
+  esac
+done
+
+scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
+source "${scripts_dir}/bazel.sh"
+"${bazel}" version
+
+cd "${scripts_dir}"
+
+set -x
+"${bazel}" ${TEST_MIGRATION:+"--strict"} test \
+  "${common_test_args[@]}" \
+  --extra_toolchains=@llvm_toolchain_msan//:all \
+  --features=msan \
+  -- //:msan_libcxx_test

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -72,6 +72,11 @@ if [[ -z "${toolchain_name}" ]]; then
   # restricted to linux because the cc_test target uses linux-only constraints.
   if [[ ${OSTYPE} == 'linux'* ]]; then
     targets+=("//:extra_files_compile_test")
+    # Runtime sanitizer tests. Tagged `manual` (so they stay out of `//:all`)
+    # and listed here only for the default toolchain: they require a sanitizer
+    # runtime new enough for the host glibc, which the pinned LLVM 13.0.0
+    # toolchain used by the container tests is not.
+    targets+=("//:asan_test" "//:ubsan_test" "//:tsan_test")
   fi
 fi
 

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -19,6 +19,7 @@
 #
 # These three Bazel flags influence whether or not `.dwo` and `.dwp` are
 # created.
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("@rules_cc//cc:defs.bzl", "CcInfo", "DebugPackageInfo")
 
 def _fission_transition_impl(settings, attr):
@@ -141,5 +142,79 @@ transition_binary_to_platform = rule(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
+    },
+)
+
+_FEATURES = "//command_line_option:features"
+
+def _sanitizer_transition_impl(settings, attr):
+    # Enable the requested sanitizer via `--features`, matching how sanitizers
+    # are turned on in normal builds (rules_cc's stock asan/ubsan/tsan
+    # features). Using a feature means Bazel resets it to `--host_features` in
+    # the exec configuration, so build tools stay uninstrumented.
+    features = [f for f in settings[_FEATURES] if f != attr.sanitizer]
+    return {_FEATURES: features + [attr.sanitizer]}
+
+_sanitizer_transition = transition(
+    implementation = _sanitizer_transition_impl,
+    inputs = [_FEATURES],
+    outputs = [_FEATURES],
+)
+
+def _sanitizer_test_impl(ctx):
+    # Re-expose the (sanitizer-enabled) binary as this test's executable.
+    exe = ctx.attr.src[0][DefaultInfo].files_to_run.executable
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.symlink(output = out, target_file = exe, is_executable = True)
+    return [DefaultInfo(
+        executable = out,
+        runfiles = ctx.attr.src[0][DefaultInfo].default_runfiles,
+    )]
+
+# Builds and runs `src` with a single sanitizer enabled via `--features`,
+# exercising the sanitizer compile/link flags and runtime end to end. Used for
+# asan/ubsan/tsan (msan needs an instrumented libc++).
+sanitizer_test = rule(
+    implementation = _sanitizer_test_impl,
+    test = True,
+    attrs = {
+        "src": attr.label(mandatory = True, cfg = _sanitizer_transition),
+        "sanitizer": attr.string(mandatory = True, values = ["asan", "ubsan", "tsan"]),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+
+def _msan_flags_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    cpp_actions = [
+        a
+        for a in analysistest.target_actions(env)
+        if a.mnemonic == "CppCompile"
+    ]
+    asserts.true(env, len(cpp_actions) > 0, "expected a CppCompile action")
+    argv = cpp_actions[0].argv
+    asserts.true(
+        env,
+        "-fsanitize=memory" in argv,
+        "expected -fsanitize=memory on the compile command line, got: %s" % argv,
+    )
+    asserts.true(
+        env,
+        [a for a in argv if "libcxx-msan" in a],
+        "expected the instrumented libc++ include path on the compile command line, got: %s" % argv,
+    )
+    return analysistest.end(env)
+
+# Analysis-only test: verifies the msan flags and instrumented-libc++ include
+# path are wired into the C++ compile action. This does not link or run, so it
+# does not require an actual instrumented libc++ build. msan is enabled through
+# the `msan` cc_feature (--features=msan), so it is reset in the exec
+# configuration and build tools stay uninstrumented.
+msan_flags_test = analysistest.make(
+    _msan_flags_test_impl,
+    config_settings = {
+        "//command_line_option:features": ["msan"],
     },
 )

--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -42,7 +42,10 @@ filegroup(
     srcs = [
         "bin/ld.lld",
         "bin/ld64.lld",
-    ] + glob(["bin/wasm-ld"], allow_empty = True),
+    ] + glob(
+        ["bin/wasm-ld"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -50,7 +53,18 @@ filegroup(
     srcs = glob([
         "include/**",
         "lib/clang/*/include/**",
-    ]),
+    ]) + glob(
+        [
+            # Sanitizer ignorelists (e.g. msan_ignorelist.txt) that Clang
+            # auto-loads from the resource directory when a sanitizer is
+            # enabled; they must be available as compiler inputs.
+            "lib/clang/*/share/**",
+            # msan-instrumented libc++ headers, present only when the
+            # distribution was configured with the `libcxx_url` attribute.
+            "libcxx-msan/include/**",
+        ],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -68,12 +82,32 @@ filegroup(
     srcs = [
         "include/c++",
         "lib/clang/{LLVM_VERSION}/include",
-    ],
+    ] + glob(
+        # Sanitizer ignorelists (e.g. msan_ignorelist.txt) auto-loaded by Clang
+        # from the resource directory when a sanitizer is enabled.
+        ["lib/clang/{LLVM_VERSION}/share"],
+        allow_empty = True,
+    ) + glob(
+        # msan-instrumented libc++ headers, present only when the distribution
+        # was configured with the `libcxx_url` attribute. Matched as source
+        # directories (exclude_directories = 0) so they are emitted as umbrella
+        # submodules in the system module map and are available as compiler
+        # inputs, matching the `include/c++` entry above.
+        [
+            "libcxx-msan/include/c++",
+            "libcxx-msan/include/*/c++",
+        ],
+        exclude_directories = 0,
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "extra_config_site",
-    srcs = glob(["include/*/c++/v1/__config_site"], allow_empty = True)
+    srcs = glob(
+        ["include/*/c++/v1/__config_site"],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
@@ -88,22 +122,37 @@ filegroup(
         # not be available at runtime to allow sanitizers to work locally.
         # Any library linked from the toolchain to be released should be linked statically.
         "lib/clang/{LLVM_VERSION}/lib",
-    ] + glob([
-        "lib/**/libc++*.a",
-        "lib/**/libunwind.a",
-    ], allow_empty = True),
+    ] + glob(
+        [
+            "lib/**/libc++*.a",
+            "lib/**/libunwind.a",
+            # msan-instrumented libc++ libraries, present only when the
+            # distribution was configured with the `libcxx_url` attribute.
+            "libcxx-msan/lib/**/lib*.a",
+        ],
+        allow_empty = True,
+    ),
 )
 
 filegroup(
     name = "lib_legacy",
-    srcs = glob([
-        # Include the .dylib files in the linker sandbox even though they will
-        # not be available at runtime to allow sanitizers to work locally.
-        # Any library linked from the toolchain to be released should be linked statically.
-        "lib/clang/{LLVM_VERSION}/lib/**",
-        "lib/**/libc++*.a",
-        "lib/**/libunwind.a",
-    ], allow_empty = True),
+    srcs = glob(
+        [
+            # Include the .dylib files in the linker sandbox even though they will
+            # not be available at runtime to allow sanitizers to work locally.
+            # Any library linked from the toolchain to be released should be linked statically.
+            "lib/clang/{LLVM_VERSION}/lib/**",
+            "lib/**/libc++*.a",
+            "lib/**/libunwind.a",
+            # msan-instrumented libc++ libraries, present only when the
+            # distribution was configured with the `libcxx_url` attribute.
+            # These must be linker-sandbox inputs; otherwise `-l:libc++.a`
+            # silently falls back to the uninstrumented base libc++.a and
+            # produces MSan false positives.
+            "libcxx-msan/lib/**/lib*.a",
+        ],
+        allow_empty = True,
+    ),
 )
 
 filegroup(

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -17,6 +17,10 @@ load(
     "@rules_cc//cc/private/toolchain:unix_cc_toolchain_config.bzl",
     unix_cc_toolchain_config = "cc_toolchain_config",
 )
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+load("@rules_cc//cc/toolchains:feature_constraint.bzl", "cc_feature_constraint")
+load("@rules_cc//cc/toolchains:feature_set.bzl", "cc_feature_set")
 load(
     "//toolchain/internal:common.bzl",
     _check_os_arch_keys = "check_os_arch_keys",
@@ -27,6 +31,26 @@ load(
 # _fmt_flags() by defining it as a nested function.
 def _fmt_flags(flags, toolchain_path_prefix):
     return [f.format(toolchain_path_prefix = toolchain_path_prefix) for f in flags]
+
+# Turn C++ standard library include dirs into search-path flags. A single
+# -nostdinc++ disables Clang's automatic libc++ header detection so our
+# explicit -cxx-isystem entries are the only ones (see the long note where
+# these are emitted).
+def _cxx_isystem(cpp_system_includes):
+    if not cpp_system_includes:
+        return []
+    return ["-nostdinc++"] + [
+        flag
+        for include in cpp_system_includes
+        for flag in ("-cxx-isystem", include)
+    ]
+
+def _idirafter(includes):
+    return [
+        flag
+        for include in includes
+        for flag in ("-idirafter", include)
+    ]
 
 # Macro for calling cc_toolchain_config from @bazel_tools with setting the
 # right paths and flags for the tools.
@@ -271,6 +295,38 @@ def cc_toolchain_config(
         "-L{}lib/{}".format(target_toolchain_path_prefix, target_system_name),
     ]
 
+    # When building with memory sanitizer, the C++ standard library must be
+    # instrumented too, otherwise msan reports false positives for any data
+    # flowing through it. The instrumented libc++ is supplied through the
+    # `libcxx_url`/`libcxx_sha256` attributes of the LLVM distribution repo,
+    # which place it under `libcxx-msan/` next to the regular toolchain. These
+    # paths are only used when msan is enabled (see the msan cc_feature below).
+    msan_cpp_system_includes = [
+        target_toolchain_path_prefix + "libcxx-msan/include/c++/v1/",
+        target_toolchain_path_prefix + "libcxx-msan/include/" + target_system_name + "/c++/v1/",
+    ]
+
+    msan_link_flags = [
+        "-L{}libcxx-msan/lib".format(target_toolchain_path_prefix),
+        "-L{}libcxx-msan/lib/{}".format(target_toolchain_path_prefix, target_system_name),
+    ]
+
+    # MemorySanitizer compile+link flags. Unlike asan/ubsan/tsan, msan must swap
+    # the C++ standard library for an instrumented libc++. On Linux this is
+    # wired through a `msan` cc_feature (see the mutually-exclusive features
+    # built near the cc_toolchain_config call), so that enabling it with
+    # `--features=msan` is reset in the exec configuration (via --host_features)
+    # and build tools stay uninstrumented.
+    #
+    # asan/ubsan/tsan are provided by rules_cc's stock sanitizer cc_features
+    # (defined in unix_cc_toolchain_config) and are likewise enabled via
+    # `--features=asan|ubsan|tsan`, so they are not wired up here.
+    msan_sanitizer_flags = [
+        "-fsanitize=memory",
+        "-fsanitize-memory-track-origins",
+        "-fsanitize-link-c++-runtime",
+    ]
+
     if exec_os == "darwin":
         # These will get expanded by osx_cc_wrapper's `sanitize_option`
         link_flags.append("--ld-path=ld64.lld" if target_os == "darwin" else "--ld-path=ld.lld")
@@ -286,6 +342,14 @@ def cc_toolchain_config(
     link_libs = []
     libunwind_link_flags = []
     compiler_rt_link_flags = []
+
+    # Standard-library-specific linker search paths (e.g. the sysroot's
+    # libstdc++/libgcc directories) and the standard library archives
+    # themselves. Kept separate from the general link_flags/link_libs so they
+    # can be swapped for the instrumented libc++ when msan is enabled (see the
+    # msan/nomsan cc_features below).
+    stdlib_link_flags = []
+    stdlib_link_libs = []
 
     is_darwin_exec_and_target = exec_os == "darwin" and target_os == "darwin"
 
@@ -425,7 +489,7 @@ def cc_toolchain_config(
         else:
             # For single-platform builds, we can statically link the bundled
             # libraries.
-            link_libs.extend([
+            stdlib_link_libs.extend([
                 "-l:libc++.a",
                 "-l:libc++abi.a",
             ])
@@ -442,7 +506,7 @@ def cc_toolchain_config(
             "-stdlib=libc++",
         ])
 
-        link_libs.extend([
+        stdlib_link_libs.extend([
             "-l:libc++.a",
             "-l:libc++abi.a",
         ])
@@ -455,7 +519,7 @@ def cc_toolchain_config(
         # <https://lists.llvm.org/pipermail/cfe-dev/2016-April/048466.html> for
         # example. This seems to be a commonly-used configuration with clang
         # though, so it's probably good enough for most people.
-        link_flags.extend([
+        stdlib_link_flags.extend([
             "-L{}lib".format(target_toolchain_path_prefix),
             "-L{}lib/{}".format(target_toolchain_path_prefix, target_system_name),
         ])
@@ -464,11 +528,11 @@ def cc_toolchain_config(
         # `--gc-sections` does not strip otherwise-unreferenced symbols (see
         # upstream #625). `dynamic_stdcxx` selects the shared variant.
         if dynamic_stdcxx:
-            link_libs.extend([
+            stdlib_link_libs.extend([
                 "-l:libstdc++.so",
             ])
         else:
-            link_libs.extend([
+            stdlib_link_libs.extend([
                 "-l:libstdc++.a",
             ])
         if stdlib == "stdc++":
@@ -488,7 +552,7 @@ def cc_toolchain_config(
             # Debian-style and Yocto-style sysroots.
             if cxx_include_layout == "yocto":
                 multiarch_cpp_include = sysroot_path + "usr/include/c++/" + libstdcxx_version + "/" + multiarch
-                link_flags.extend([
+                stdlib_link_flags.extend([
                     "-B{}usr/lib/{}/{}/".format(sysroot_path, multiarch, libstdcxx_version),
                     "-Wl,-L{}usr/lib/{}/{}/".format(sysroot_path, multiarch, libstdcxx_version),
                 ])
@@ -507,7 +571,7 @@ def cc_toolchain_config(
             nostdinc = True
             system_includes.append(toolchain_builtin_include)
 
-            link_flags.extend([
+            stdlib_link_flags.extend([
                 "-L" + sysroot_path + "usr/lib/gcc/" + multiarch + "/" + libstdcxx_version,
             ])
         else:
@@ -611,22 +675,17 @@ def cc_toolchain_config(
     # Turn the accumulated include directories into search-path flags. The C++
     # standard library dirs are searched first (-cxx-isystem) and the C/system
     # dirs after them (-idirafter), which is what Clang expects.
-    # TODO(AustinSchuh): Add msan support and make this conditional.
-    if cpp_system_includes:
-        cxx_flags = ["-nostdinc++"] + [
-            flag
-            for include in cpp_system_includes
-            for flag in ("-cxx-isystem", include)
-        ] + cxx_flags
-    if nostdinc:
-        compile_flags.append("-nostdinc")
-    compile_flags += [
-        flag
-        for include in system_includes
-        for flag in ("-idirafter", include)
-    ]
-
-    # Add the sysroot flags here, as we want to check these last
+    #
+    # Two include-path variants are computed: the configured stdlib's headers
+    # and the instrumented libc++ that msan requires. msan always uses the
+    # instrumented libc++ (an instrumented runtime requires an instrumented
+    # standard library), so even when the configured stdlib is libstdc++ the
+    # msan variant switches to the libc++ headers and drops -nostdinc (Clang
+    # then derives the sysroot's C system includes from --sysroot, exactly as a
+    # normal libc++ build does). On Linux the two variants are carried by the
+    # msan/nomsan cc_features; on other platforms the configured-stdlib variant
+    # is folded into compile_flags/cxx_flags at the cc_toolchain_config call.
+    external_include_paths = []
     if sysroot_path != None:
         external_include_paths = [
             sysroot_path + "usr/local/include",
@@ -636,27 +695,179 @@ def cc_toolchain_config(
                 sysroot_path + "usr/" + multiarch + "/include",
                 sysroot_path + "usr/include/" + multiarch,
             ])
-
         external_include_paths.extend([
             sysroot_path + "usr/include",
             sysroot_path + "include",
         ])
 
-        if nostdinc:
-            # With -nostdinc Clang no longer derives the sysroot's C system
-            # include paths from --sysroot, so add them explicitly. Emit them
-            # as -idirafter so they are searched after the compiler builtin
-            # headers (system_includes, above) and the C++ standard library
-            # headers (cpp_system_includes, via -cxx-isystem). Clang orders the
-            # -cxx-isystem (CXXSystem) group after the -isystem (System) group,
-            # so the C library headers must land in the later -idirafter (After)
-            # group for #include_next from libstdc++ wrappers like <cstdlib> to
-            # resolve to them.
-            compile_flags += [
-                flag
-                for p in external_include_paths
-                for flag in ("-idirafter", p)
-            ]
+    # Configured-stdlib include flags. With -nostdinc (libstdc++) Clang no
+    # longer derives the sysroot's C system include paths from --sysroot, so
+    # add them explicitly as -idirafter; they are searched after the compiler
+    # builtin headers (system_includes) and the C++ standard library headers
+    # (cpp_system_includes, via -cxx-isystem). Clang orders the -cxx-isystem
+    # (CXXSystem) group after the -isystem (System) group, so the C library
+    # headers must land in the later -idirafter (After) group for #include_next
+    # from libstdc++ wrappers like <cstdlib> to resolve to them.
+    normal_compile_include_flags = (["-nostdinc"] if nostdinc else []) + _idirafter(system_includes)
+    if sysroot_path != None and nostdinc:
+        normal_compile_include_flags = normal_compile_include_flags + _idirafter(external_include_paths)
+
+    # Instrumented-libc++ include flags (msan). Uses the toolchain's builtin
+    # headers via -idirafter with -nostdinc left off so the sysroot's C system
+    # headers are auto-derived from --sysroot.
+    msan_compile_include_flags = _idirafter([toolchain_builtin_include])
+
+    # Two C++-standard-library variants: the configured stdlib (the "default"
+    # branch below) and the instrumented libc++ that msan requires. On Linux
+    # these are wired into mutually-exclusive cc_features so msan can be toggled
+    # with `--features=msan` (which Bazel resets to `--host_features` in the
+    # exec configuration, keeping build tools uninstrumented). MSan is only
+    # supported on Linux, so elsewhere only the configured stdlib is used.
+    default_cxx_isystem_flags = _cxx_isystem(cpp_system_includes)
+    msan_cxx_isystem_flags = _cxx_isystem(msan_cpp_system_includes)
+    default_link_search_flags = non_msan_link_flags if use_toolchain_libcxx_paths else stdlib_link_flags
+
+    # msan forces libc++ (-stdlib=libc++) and links the instrumented libc++
+    # instead of libstdc++/libgcc, so it additionally needs compiler-rt and
+    # libunwind.
+    msan_extra_link_flags = msan_link_flags + ["-stdlib=libc++", "-rtlib=compiler-rt", "-l:libunwind.a", "-lpthread", "-ldl"]
+    msan_link_libs = ["-l:libc++.a", "-l:libc++abi.a"]
+
+    is_linux = target_os == "linux"
+
+    msan_feature_labels = []
+    nomsan_feature_labels = []
+    if is_linux:
+        # msan is enabled via `--features=msan`. The `msan` cc_feature carries
+        # the instrumented-libc++ and sanitizer flags; the default-stdlib flags
+        # live in an always-on `<name>_nomsan_stdlib` feature whose args are
+        # gated `none_of = [msan]`, so enabling msan swaps the configured C++
+        # standard library for the instrumented libc++. Build tools run in the
+        # exec config, where --features is reset to --host_features, so they
+        # keep the default (uninstrumented) stdlib and stay uninstrumented.
+        cc_args(
+            name = name + "_msan_compile_args",
+            actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+            args = msan_compile_include_flags + msan_sanitizer_flags,
+        )
+        cc_args(
+            name = name + "_msan_cxx_args",
+            actions = ["@rules_cc//cc/toolchains/actions:cpp_compile_actions"],
+            args = msan_cxx_isystem_flags,
+        )
+        cc_args(
+            name = name + "_msan_link_args",
+            actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+            args = msan_extra_link_flags + msan_link_libs + msan_sanitizer_flags,
+        )
+        cc_feature(
+            name = name + "_msan",
+            feature_name = "msan",
+            args = [
+                ":" + name + "_msan_compile_args",
+                ":" + name + "_msan_cxx_args",
+                ":" + name + "_msan_link_args",
+            ],
+        )
+        msan_feature_labels = [":" + name + "_msan"]
+
+        # Constraint satisfied only when the msan feature is NOT enabled. The
+        # default-stdlib args below require it, so they are dropped under msan.
+        cc_feature_set(
+            name = name + "_msan_set",
+            all_of = [":" + name + "_msan"],
+        )
+        cc_feature_constraint(
+            name = name + "_not_msan",
+            none_of = [":" + name + "_msan_set"],
+        )
+
+        nomsan_args = []
+        if normal_compile_include_flags:
+            cc_args(
+                name = name + "_nomsan_compile_args",
+                actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+                args = normal_compile_include_flags,
+                requires_any_of = [":" + name + "_not_msan"],
+            )
+            nomsan_args.append(":" + name + "_nomsan_compile_args")
+        if default_cxx_isystem_flags:
+            cc_args(
+                name = name + "_nomsan_cxx_args",
+                actions = ["@rules_cc//cc/toolchains/actions:cpp_compile_actions"],
+                args = default_cxx_isystem_flags,
+                requires_any_of = [":" + name + "_not_msan"],
+            )
+            nomsan_args.append(":" + name + "_nomsan_cxx_args")
+        nomsan_link_flags = default_link_search_flags + stdlib_link_libs
+        if nomsan_link_flags:
+            cc_args(
+                name = name + "_nomsan_link_args",
+                actions = ["@rules_cc//cc/toolchains/actions:link_actions"],
+                args = nomsan_link_flags,
+                requires_any_of = [":" + name + "_not_msan"],
+            )
+            nomsan_args.append(":" + name + "_nomsan_link_args")
+
+        # Enabled by default via extra_enabled_features below (the cc_feature
+        # rule always declares features disabled; the enabled state is set when
+        # the toolchain wires it through extra_enabled_features).
+        cc_feature(
+            name = name + "_nomsan_stdlib",
+            feature_name = name + "_nomsan_stdlib",
+            args = nomsan_args,
+        )
+        nomsan_feature_labels = [":" + name + "_nomsan_stdlib"]
+
+        # The stdlib include/link flags live in the msan/nomsan cc_features
+        # above, so keep them out of the always-on baked flag lists.
+        baked_compile_include_flags = []
+        baked_cxx_isystem_flags = []
+        baked_link_stdlib_flags = []
+        baked_link_libs_stdlib = []
+    else:
+        # MSan is only supported on Linux (where it is wired through the `msan`
+        # cc_feature above), so non-Linux toolchains always use the configured
+        # standard library and never the instrumented libc++.
+        baked_compile_include_flags = normal_compile_include_flags
+        baked_cxx_isystem_flags = default_cxx_isystem_flags
+        baked_link_stdlib_flags = default_link_search_flags
+        baked_link_libs_stdlib = stdlib_link_libs
+
+    # asan/ubsan/tsan are rules_cc's stock sanitizer cc_features, enabled via
+    # `--features=asan|ubsan|tsan`. They link via a plain `-fsanitize=...`, which
+    # does not pull Clang's C++ sanitizer runtime, so C++ programs fail to link
+    # (e.g. ubsan's vptr handlers, __ubsan_*_type_cache). Augment each stock
+    # feature with `-fsanitize-link-c++-runtime`; ubsan additionally gets
+    # `-fsanitize=bounds` and `-fsanitize=nullability` (checks not in the default
+    # `undefined` group).
+    #
+    # The augmentation flags are selected on config_settings that match
+    # `--features=...` (see //toolchain/config). Keying on `--features` (rather
+    # than a //toolchain/config flag) means the augmentation is reset to
+    # `--host_features` in the exec configuration, so build tools stay
+    # uninstrumented -- matching how the stock features themselves behave.
+    sanitizer_compile_flags = select({
+        str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
+            "-fsanitize=bounds",
+            "-fsanitize=nullability",
+        ],
+        "//conditions:default": [],
+    })
+    sanitizer_link_flags = select({
+        str(Label("@toolchains_llvm//toolchain/config:use_asan")): [
+            "-fsanitize-link-c++-runtime",
+        ],
+        str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
+            "-fsanitize-link-c++-runtime",
+            "-fsanitize=bounds",
+            "-fsanitize=nullability",
+        ],
+        str(Label("@toolchains_llvm//toolchain/config:use_tsan")): [
+            "-fsanitize-link-c++-runtime",
+        ],
+        "//conditions:default": [],
+    })
 
     if compiler_configuration["extra_compile_flags"] != None:
         compile_flags.extend(_fmt_flags(compiler_configuration["extra_compile_flags"], toolchain_path_prefix))
@@ -694,23 +905,33 @@ def cc_toolchain_config(
         abi_libc_version = abi_libc_version,
         cxx_builtin_include_directories = cxx_builtin_include_directories,
         tool_paths = tool_paths,
-        compile_flags = compile_flags,
+        compile_flags = compile_flags + baked_compile_include_flags + sanitizer_compile_flags,
         fastbuild_compile_flags = fastbuild_compile_flags,
         dbg_compile_flags = dbg_compile_flags,
         opt_compile_flags = opt_compile_flags,
         conly_flags = conly_flags,
-        cxx_flags = cxx_flags,
+        cxx_flags = baked_cxx_isystem_flags + cxx_flags,
         link_flags = link_flags + select({str(Label("@toolchains_llvm//toolchain/config:use_libunwind")): libunwind_link_flags, "//conditions:default": []}) +
                      select({str(Label("@toolchains_llvm//toolchain/config:use_compiler_rt")): compiler_rt_link_flags, "//conditions:default": []}) +
-                     (non_msan_link_flags if use_toolchain_libcxx_paths else []),
+                     # Standard library search paths and msan's libc++ forcing
+                     # flags. On Linux these live in the msan/nomsan cc_features
+                     # (baked_link_stdlib_flags is empty); elsewhere only the
+                     # configured stdlib's search paths are used.
+                     baked_link_stdlib_flags +
+                     # asan/ubsan/tsan C++ runtime linking and ubsan's extra
+                     # checks, selected on the matching --features (see above).
+                     sanitizer_link_flags,
         archive_flags = archive_flags,
-        link_libs = link_libs,
+        # Standard library archives. On Linux these live in the cc_features
+        # (baked_link_libs_stdlib is empty); elsewhere the configured stdlib's
+        # archives.
+        link_libs = baked_link_libs_stdlib + link_libs,
         opt_link_flags = opt_link_flags,
         unfiltered_compile_flags = unfiltered_compile_flags,
         coverage_compile_flags = coverage_compile_flags,
         coverage_link_flags = coverage_link_flags,
         supports_start_end_lib = supports_start_end_lib,
         builtin_sysroot = sysroot_path,
-        extra_enabled_features = extra_enabled_features,
-        extra_known_features = extra_known_features,
+        extra_enabled_features = nomsan_feature_labels + extra_enabled_features,
+        extra_known_features = msan_feature_labels + extra_known_features,
     )

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -37,3 +37,41 @@ config_setting(
     flag_values = {":compiler-rt": "True"},
     visibility = ["//visibility:public"],
 )
+
+# Sanitizers are enabled via Bazel features, not //toolchain/config flags:
+#
+#   --features=asan      (AddressSanitizer)
+#   --features=ubsan     (UndefinedBehaviorSanitizer)
+#   --features=tsan      (ThreadSanitizer)
+#   --features=msan      (MemorySanitizer; Linux only)
+#
+# asan/ubsan/tsan are rules_cc's stock sanitizer cc_features. msan is wired up
+# in cc_toolchain_config.bzl because it must swap in an instrumented libc++
+# (supplied via the `libcxx_url`/`libcxx_sha256` attributes of the LLVM
+# distribution repo). Using features (rather than flags) lets Bazel reset them
+# to `--host_features` in the exec configuration, so build tools stay
+# uninstrumented.
+#
+# The config_settings below match `--features=asan|ubsan|tsan` so
+# cc_toolchain_config.bzl can `select()` extra flags onto the stock features
+# (the C++ sanitizer runtime, and ubsan's bounds/nullability checks). Matching
+# on `--features` keeps the exec-configuration reset: the extra flags are
+# dropped for build tools just like the stock features are.
+
+config_setting(
+    name = "use_asan",
+    values = {"features": "asan"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "use_ubsan",
+    values = {"features": "ubsan"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "use_tsan",
+    values = {"features": "tsan"},
+    visibility = ["//visibility:public"],
+)

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -518,9 +518,23 @@ def _cc_toolchain_str(
     cxx_builtin_include_directories = [
         target_toolchain_include_path_prefix + "include/c++/v1",
         target_toolchain_include_path_prefix + "lib/clang/{}/include".format(resource_dir_version),
+        # Sanitizer ignorelists (e.g. msan_ignorelist.txt) that Clang auto-loads
+        # from the resource directory when a sanitizer is enabled; declared here
+        # so Bazel's include validation accepts them as builtin toolchain files.
+        target_toolchain_include_path_prefix + "lib/clang/{}/share".format(resource_dir_version),
         # Note(zbarsky): We could avoid this path if we renamed `include/{target_system_name}/c++/v1/__config_site` to `include/c++/v1/__config_site` in the LLVM repo.
         # However, that would preclude sharing it across multiple toolchain definitions.
         target_toolchain_include_path_prefix + "include/{}/c++/v1".format(target_system_name),
+        # MSan-instrumented libc++ headers (present only when the distribution
+        # was configured with `libcxx_url`). msan builds compile against these
+        # via -cxx-isystem (see msan_cpp_system_includes in
+        # cc_toolchain_config.bzl), so they must be declared builtin includes
+        # for both Bazel's include validation and the generated system module
+        # map. Without this, `layering_check` fails for libraries (e.g. abseil)
+        # that include standard headers under msan. Non-existent when no msan
+        # overlay is configured; the module map generator filters absent dirs.
+        target_toolchain_include_path_prefix + "libcxx-msan/include/c++/v1",
+        target_toolchain_include_path_prefix + "libcxx-msan/include/{}/c++/v1".format(target_system_name),
     ]
 
     # TODO(zbarsky): Not sure if these lib64 paths are actually needed for system toolchains?

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -160,6 +160,16 @@ def download_llvm(rctx):
                 lib_path = clang_version.get_child("lib", lib_name)
                 rctx.file(lib_path, libclang_rt_content, legacy_utf8 = False)
 
+    # Optionally overlay a memory-sanitizer-instrumented libc++ used by msan
+    # builds (enabled with `--features=msan`; see cc_toolchain_config.bzl).
+    if rctx.attr.libcxx_url:
+        rctx.download_and_extract(
+            [_full_url(rctx.attr.libcxx_url)],
+            sha256 = rctx.attr.libcxx_sha256,
+            output = "libcxx-msan",
+            auth = _get_auth(rctx, [rctx.attr.libcxx_url]),
+        )
+
     updated_attrs = attr_dict(rctx.attr)
     if update_sha256:
         updated_attrs["sha256"].update([(key, res.sha256)])

--- a/toolchain/internal/repo.bzl
+++ b/toolchain/internal/repo.bzl
@@ -120,6 +120,18 @@ llvm_repo_attrs.update({
                "distribution. The key is the label of a libclang_rt library, " +
                "and the value is `\"{llvm_target_name}/{library_name}.a\"`."),
     ),
+    "libcxx_url": attr.string(
+        mandatory = False,
+        doc = ("URL of an archive containing a memory-sanitizer-instrumented build of " +
+               "libc++ (headers under `include/` and libraries under `lib/`). When set, " +
+               "it is extracted into `libcxx-msan/` in the distribution and used in place " +
+               "of the regular libc++ for builds with MemorySanitizer enabled " +
+               "(`--features=msan`, Linux only)."),
+    ),
+    "libcxx_sha256": attr.string(
+        mandatory = False,
+        doc = "The expected SHA-256 of the archive downloaded as per the `libcxx_url` attribute.",
+    ),
     "netrc": attr.string(
         mandatory = False,
         doc = "Path to the netrc file for authenticated LLVM URL downloads.",


### PR DESCRIPTION
This adds end-to-end MemorySanitizer (msan) support and moves AddressSanitizer/UndefinedBehaviorSanitizer/ThreadSanitizer off the `//toolchain/config` flags onto Bazel features, with an end-to-end msan CI job that exercises the instrumented libc++.

Why features instead of `//toolchain/config` flags --------------------------------------------------- Sanitizers must instrument the *target* program but must NOT instrument the build tools that run in the exec configuration (e.g. `flatc`, protoc plugins). A `bool_flag`/`config_setting` is a global build setting in bazel 8: it propagates into the exec configuration, so enabling it instruments the build tools too. Under msan that makes the tools abort at startup; under asan/ubsan it needlessly slows them and can break them.

Bazel resets `--features` to `--host_features` in the exec configuration, so a feature-enabled sanitizer is automatically dropped for build tools. That is the property we want, and it is why msan is wired through a `msan` cc_feature and why asan/ubsan/tsan now use rules_cc's stock `asan`/`ubsan`/`tsan` features (`--features=asan|ubsan|tsan|msan`). The old `//toolchain/config:{asan,ubsan}` flags are removed.

MemorySanitizer and the instrumented libc++
-------------------------------------------
msan reports false positives unless the C++ standard library is also instrumented, so msan swaps in an instrumented libc++ supplied via the new `libcxx_url`/`libcxx_sha256` attributes (extracted to `libcxx-msan/`). On Linux this is wired through mutually exclusive cc_features: the `msan` feature carries the instrumented-libc++ include/link flags, and an always-on `*_nomsan_stdlib` feature (gated `none_of [msan]`) carries the default stdlib flags, so enabling `--features=msan` swaps the standard library. msan is Linux-only.

The instrumented archives and headers must be available as toolchain inputs in BOTH filegroup layouts Bazel uses:

  * Bazel < 9 (no merkle_cache_v2): linker uses `lib_legacy`, compiler uses `include`.
  * Bazel >= 9 (merkle_cache_v2): linker uses `lib`, compiler uses `cxx_builtin_include`.

Pitfall (fixed here): if the overlay is added to only one variant, the build silently degrades instead of failing loudly:
  * A missing `libcxx-msan/lib/*.a` makes `-l:libc++.a` fall back to the *uninstrumented* base `libc++.a`. The link still succeeds, but msan then reports use-of-uninitialized-value deep inside libc++ (e.g. `std::ios_base::precision`) for any program that touches iostreams.
  * A missing `libcxx-msan/include/...` makes the instrumented headers absent from the compile sandbox (`'cstdio' file not found`). Both the `include`/`lib_legacy` and `cxx_builtin_include`/`lib` filegroups now carry the overlay, so msan works identically on Bazel 8 and 9.

Augmenting the stock sanitizer features
---------------------------------------
rules_cc's stock asan/ubsan/tsan features link via a plain `-fsanitize=...`, which does not pull Clang's C++ sanitizer runtime. C++ programs then fail to link (ubsan's vptr handlers: undefined `__ubsan_vptr_type_cache`, `__ubsan_handle_dynamic_type_cache_miss_abort`). We therefore augment each stock feature with `-fsanitize-link-c++-runtime`, and add ubsan's `-fsanitize=bounds` / `-fsanitize=nullability` (checks outside the default `undefined` group).

The augmentation is applied with a `select()` keyed on `config_setting`s that match `--features=asan|ubsan|tsan`. Keying on `--features` (rather than a `//toolchain/config` flag) keeps the exec-configuration reset, so the extra flags are dropped for build tools exactly like the stock features.

Rejected alternatives:
  * Defining our own cc_features named `asan`/`ubsan`/`tsan`: Bazel rejects this with "feature ... specified multiple times" because unix_cc_toolchain_config already emits them; overriding requires a `cc_external_feature` target.
  * Gating the extra flags on the stock features with `cc_external_feature` / `cc_feature_constraint`: `cc_external_feature` (and the provider file `cc_toolchain_info.bzl` it needs) are `visibility()`-restricted to `//cc/toolchains/...` in rules_cc (through 0.2.19), so they cannot be loaded from this repo, and the rule cannot be vendored either.
  * Adding the flags unconditionally: `-fsanitize=bounds`/`nullability` would instrument every build, and the flags would leak into the exec config.

Tests / CI
----------
  * `//:msan_libcxx_test` builds and runs an instrumented-libc++ program (the iostream/precision pattern above) with the `@llvm_toolchain_msan` toolchain and `--features=msan`. Unlike the analysis-only `msan_flags_test`, it links and runs, so it catches an uninstrumented libc++ being linked.
  * A dedicated `msan_test` CI job runs it across Bazel 7/8/9/latest so both filegroup layouts are exercised; it is wired into the `required_checks_done` gate.
  * `sanitizer_test` now enables sanitizers via `--features` and gains a `tsan_test`; asan/ubsan/tsan are verified to link and run end to end.