### PR TITLE
osx: load sanitizer runtime dylibs via @loader_path rpath (fixes #192)

### DIFF
--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -226,3 +226,30 @@ for rpath in ${RPATHS}; do
     fi
   done
 done
+
+# Sanitizer runtimes (e.g. libclang_rt.asan_osx_dynamic.dylib) are linked with an
+# `@rpath/<name>` install name, and Clang adds a *toolchain-relative* LC_RPATH
+# (`external/.../lib/clang/<v>/lib/darwin`) that only resolves when the process's
+# working directory is the execroot -- true at link time, but not when a test
+# runs from its runfiles, so the dylib is "not loaded" at runtime. Add an
+# `@loader_path`-relative LC_RPATH to the toolchain's compiler-rt darwin dir so
+# `@rpath` resolves regardless of the working directory -- no absolute paths
+# (which break the sandbox) and no copying the dylib into runfiles. Only for the
+# hermetic (relative-prefix) toolchain; the host toolchain finds it normally.
+if [[ ${toolchain_path_prefix} != /* ]] && [[ -n ${OUTPUT} && ${OUTPUT} != "1" && -f ${OUTPUT} ]]; then
+  if /usr/bin/otool -L "${OUTPUT}" 2>/dev/null | grep -q '@rpath/libclang_rt\.'; then
+    output_dir="$(dirname_shim "${OUTPUT}")"
+    # One `../` per component of OUTPUT's dir climbs from `@loader_path` back to
+    # the execroot, which is also where `external/...` (the toolchain) lives.
+    loader_to_execroot=""
+    IFS='/' read -ra output_parts <<<"${output_dir}"
+    for _part in "${output_parts[@]}"; do
+      loader_to_execroot="../${loader_to_execroot}"
+    done
+    for darwin_dir in "${toolchain_path_prefix}"lib/clang/*/lib/darwin; do
+      [[ -d ${darwin_dir} ]] || continue
+      "${INSTALL_NAME_TOOL}" -add_rpath \
+        "@loader_path/${loader_to_execroot}${darwin_dir}" "${OUTPUT}" 2>/dev/null || true
+    done
+  fi
+fi


### PR DESCRIPTION
## Problem

Linking with `-fsanitize=address` (or ubsan/tsan) on macOS references the runtime as `@rpath/libclang_rt.<san>_osx_dynamic.dylib`, and Clang adds a *toolchain-relative* `LC_RPATH` (`external/.../lib/clang/<v>/lib/darwin`). That rpath is relative to the working directory, so it only resolves when cwd is the execroot — true at link time, but `bazel test` runs the binary from its runfiles, where the path doesn't exist:

```
dyld: Library not loaded: @rpath/libclang_rt.asan_osx_dynamic.dylib
```

This is why `--features=asan` doesn't work on macOS (#192). Workarounds people reach for don't hold up: `absolute_paths = True` makes the rpath absolute but breaks sandboxed builds (#184), and adding the toolchain libs as a `data` dep doesn't help under bzlmod (the rpath's `external/<canonical>` layout doesn't exist in bzlmod runfiles).

## Fix

After linking, if the output references a `@rpath/libclang_rt.*` dylib, add an `@loader_path`-relative `LC_RPATH` to the toolchain's compiler-rt `darwin` directory. `@loader_path` is relative to the binary rather than the working directory, so `@rpath` resolves wherever the binary runs — no `absolute_paths`, no copying the dylib into runfiles.

- Scoped to the hermetic (relative-prefix) toolchain; the host toolchain finds the runtime itself.
- Only fires when a sanitizer runtime is actually linked, so non-sanitized builds are unaffected.

## Testing

macOS 26 / Apple Silicon, LLVM 22.1.7: a downstream project's full AddressSanitizer suite (74 targets) passes with no `absolute_paths` and no data deps. (Note: LLVM ≤ 20 separately hangs in compiler-rt `FindDynamicShadowStart` on macOS 26, unrelated to this rpath fix.)

Fixes #192
