### PR TITLE
Add support for riscv64-unknown-none-elf targets

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -162,6 +162,15 @@ def cc_toolchain_config(
             "unknown",
             None,
         ),
+        "none-riscv64": (
+            "clang-riscv64-none",
+            "riscv64",
+            "unknown",
+            "clang",
+            "unknown",
+            "unknown",
+            None,
+        ),
         "none-x86_64": (
             "clang-x86_64-none",
             "k8",

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -22,6 +22,7 @@ SUPPORTED_TARGETS = [
     ("darwin", "x86_64"),
     ("darwin", "aarch64"),
     ("none", "riscv32"),
+    ("none", "riscv64"),
     ("none", "wasm32"),
     ("none", "wasm64"),
     ("none", "x86_64"),
@@ -32,6 +33,7 @@ SUPPORTED_TARGETS = [
 # These are targets that can build without a sysroot.
 SUPPORTED_NO_SYSROOT_TARGETS = [
     ("none", "riscv32"),
+    ("none", "riscv64"),
     ("none", "x86_64"),
 ]
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -491,6 +491,7 @@ def _cc_toolchain_str(
         "linux-x86_64": "x86_64-unknown-linux-gnu",
         "linux-riscv64": "riscv64-unknown-linux-gnu",
         "none-riscv32": "riscv32-unknown-none-elf",
+        "none-riscv64": "riscv64-unknown-none-elf",
         "none-x86_64": "x86_64-unknown-none",
         "wasm32": "wasm32-unknown-unknown",
         "wasm64": "wasm64-unknown-unknown",


### PR DESCRIPTION
Add support for riscv64 baremetal targets (Such as Microchip PolarFire SoCs)