### PR TITLE
osx: sanitizer runtime via dynamic_runtime_lib + @loader_path rpath (fixes #192)

### DIFF
--- a/docs/osx-sanitizer-runtime.md
+++ b/docs/osx-sanitizer-runtime.md
@@ -29,7 +29,7 @@ relative to the process's working directory, so it only works when the binary
 runs from the execroot — true at link time, false when `bazel test` runs the
 binary from its runfiles:
 
-```
+```text
 dyld: Library not loaded: @rpath/libclang_rt.asan_osx_dynamic.dylib
 ```
 
@@ -109,7 +109,7 @@ The resulting `cc_test` binary gets exactly the right structure — three
 `@loader_path` rpaths covering both execution contexts, plus the dylib
 physically present in runfiles:
 
-```
+```console
 $ otool -l no_destruct_test | grep -A2 LC_RPATH | grep path
   @loader_path/../../_solib_<toolchain>/                                 # from bazel-bin
   @loader_path/no_destruct_test.runfiles/_main/_solib_<toolchain>/      # as test

--- a/docs/osx-sanitizer-runtime.md
+++ b/docs/osx-sanitizer-runtime.md
@@ -1,0 +1,183 @@
+# macOS sanitizer runtime loading — findings
+
+Investigation into why `--features=asan` fails at runtime on macOS
+([#192](https://github.com/bazel-contrib/toolchains_llvm/issues/192)), and a
+comparison of two fixes:
+
+- **A. Post-link rpath rewrite** (PR
+  [#767](https://github.com/bazel-contrib/toolchains_llvm/pull/767), branch
+  `osx-sanitizer-runtime-rpath`): after linking, add an `@loader_path`-relative
+  `LC_RPATH` pointing back to the toolchain's compiler-rt directory.
+- **B. `dynamic_runtime_lib`** (branch `osx-sanitizer-dynamic-runtime-lib`,
+  this document's branch): expose the sanitizer runtime dylib through the
+  `cc_toolchain.dynamic_runtime_lib` attribute so Bazel links it via the solib
+  directory and ships it in the binary's runfiles.
+
+Both were validated against the full `helly25/mbo` test suite (74 test
+targets) on macOS 26 / Apple Silicon with LLVM 22.1.7, using
+`--override_module=toolchains_llvm=<local checkout>` and mbo's
+`--config=clang --config=asan`.
+
+## The problem
+
+On macOS the sanitizer runtimes are **dynamic-only**: linking with
+`-fsanitize=address` (or thread/undefined) records
+`@rpath/libclang_rt.asan_osx_dynamic.dylib` in the binary (the dylib's install
+name), and Clang adds a _toolchain-relative_ `LC_RPATH`
+(`external/<llvm repo>/lib/clang/<v>/lib/darwin`). That path is resolved
+relative to the process's working directory, so it only works when the binary
+runs from the execroot — true at link time, false when `bazel test` runs the
+binary from its runfiles:
+
+```
+dyld: Library not loaded: @rpath/libclang_rt.asan_osx_dynamic.dylib
+```
+
+On Linux this problem does not exist because the sanitizer runtimes are static
+archives linked into the binary.
+
+## Approach A: post-link `@loader_path` rpath (PR #767)
+
+The osx wrapper (`osx_cc_wrapper.sh.tpl`) checks the linked output with
+`otool -L`; if it references `@rpath/libclang_rt.*`, it adds an
+`LC_RPATH` of the form `@loader_path/<../ per output-dir component>/external/
+<llvm repo>/lib/clang/<v>/lib/darwin` via `install_name_tool -add_rpath`.
+`@loader_path` resolves relative to the binary's real path (runfiles entries
+are symlinks into the execroot), so the toolchain directory is found no matter
+the working directory.
+
+**Validation: 74/74 mbo asan tests pass.**
+
+Properties:
+
+- Covers **all link modes** — `cc_test`, `cc_binary` (default
+  `linkstatic = 1`), binaries run via `sh_test`/`data`.
+- No change to link inputs or runfiles; zero overhead for non-sanitized
+  builds (the rewrite only fires when a sanitizer runtime is referenced).
+- **Local-execution only**: the rpath points back into the build machine's
+  execroot (`external/...`). It breaks for remote execution, for
+  `--remote_download_minimal`, and for binaries copied out of `bazel-out`.
+
+## Approach B: `dynamic_runtime_lib` (this branch)
+
+### How the mechanism works (rules_cc / Bazel 9)
+
+- `cc_toolchain.{static,dynamic}_runtime_lib` are only consulted when the
+  feature **`static_link_cpp_runtimes`** is enabled
+  (`cc_toolchain_info.bzl`); with the feature on, _both_ attributes must be
+  set or analysis fails.
+- The choice between them follows the **linking mode**
+  (`cc_binary.bzl: _get_link_staticness`):
+  - `cc_test` defaults to `linkstatic = False` on non-Windows →
+    `LINKING_DYNAMIC` → `dynamic_runtime_lib` is linked (as a
+    `library_to_link(dynamic_library = ...)` via the solib directory) **and
+    added to the test's runfiles**.
+  - `cc_binary` defaults to `linkstatic = True` → `LINKING_STATIC` →
+    `static_runtime_lib` is used; nothing reaches runfiles.
+- On darwin, rules_cc's `runtime_library_search_directories` feature emits
+  dyld-native `@loader_path/...` rpaths (the `$ORIGIN` form is Linux-only),
+  so no wrapper post-processing is needed.
+- The stock `static_link_cpp_runtimes` feature is defined (disabled) inside
+  `unix_cc_toolchain_config` and cannot be enabled from outside directly:
+  `extra_enabled_features` drops external feature references
+  (`legacy_converter.bzl: convert_feature` returns `None` for
+  `feature.external`). It **can** be enabled transitively: a `cc_feature`
+  that `implies` the predefined
+  `@rules_cc//cc/toolchains/features:static_link_cpp_runtimes` target.
+
+### Implementation (3 files)
+
+1. `toolchain/BUILD.llvm_repo.tpl` — filegroups
+   `libclang_rt-{asan,tsan,ubsan}-darwin` globbing
+   `lib/clang/<v>/lib/darwin/libclang_rt.<san>_osx_dynamic.dylib`
+   (empty on non-darwin distributions).
+2. `toolchain/cc_toolchain_config.bzl` — darwin-only `cc_feature`
+   `<name>_sanitizer_runtime_runfiles` that `implies`
+   `static_link_cpp_runtimes`, wired into `extra_enabled_features` under a
+   `select()` on the existing `use_asan`/`use_ubsan`/`use_tsan`
+   config settings (which match `--features=...`, so exec-configuration
+   builds stay unaffected).
+3. `toolchain/internal/configure.bzl` — the generated `cc_toolchain` sets
+   `static_runtime_lib` (empty filegroup) and `dynamic_runtime_lib`
+   (`select()` picking the matching sanitizer dylib filegroup). Scoped to
+   darwin hermetic toolchains; the host toolchain finds its runtime at its
+   absolute location.
+
+### Validation: 73/74 mbo asan tests pass
+
+The resulting `cc_test` binary gets exactly the right structure — three
+`@loader_path` rpaths covering both execution contexts, plus the dylib
+physically present in runfiles:
+
+```
+$ otool -l no_destruct_test | grep -A2 LC_RPATH | grep path
+  @loader_path/../../_solib_<toolchain>/                                 # from bazel-bin
+  @loader_path/no_destruct_test.runfiles/_main/_solib_<toolchain>/      # as test
+  @loader_path/_solib_<toolchain>/
+  @executable_path
+  external/<llvm repo>/lib/clang/22/lib/darwin                           # Clang's own (cwd-relative)
+
+$ ls no_destruct_test.runfiles/_main/_solib_<toolchain>/
+libclang_rt.asan_osx_dynamic.dylib
+```
+
+The **one failure** is structural, not a bug: `//mbo/file:glob_sh_test` is an
+`sh_test` that runs a `cc_binary` (`mbo/file/glob`) from its runfiles. The
+binary links in static mode (`linkstatic = 1` default) → takes the
+`static_runtime_lib` branch (empty — macOS has **no static asan runtime**) →
+keeps only Clang's cwd-relative rpath → `Abort trap: 6` at load. Approach A
+covers this case; approach B cannot, short of requiring `linkstatic = 0` on
+sanitized binaries.
+
+## Side finding: LLVM 20.1.8 asan deadlocks at init on macOS 26
+
+Independent of either fix: 20.1.8's compiler-rt hangs (100 % CPU spin before
+`main`) under asan on macOS 26. Sampled stack:
+`__asan::AsanInitInternal → InitializeShadowMemory → MemoryRangeIsAvailable →
+get_dyld_hdr → dyld_shared_cache_iterate_text_swift (new Swift dyld API) →
+_Block_copy → malloc` — which re-enters the asan-wrapped malloc zone and
+spins on the init `StaticSpinMutex` already held by the outer init.
+Fixed in later compiler-rt; mbo's CI already excludes the combo and runs
+macOS asan on LLVM ≥ 21. Any macOS asan testing must use 21.1.8+/22.1.7.
+
+## Comparison
+
+|                                                                    | A: wrapper rpath (#767)               | B: `dynamic_runtime_lib`             |
+| ------------------------------------------------------------------ | ------------------------------------- | ------------------------------------ |
+| `cc_test` (default linkstatic=0)                                   | ✅                                    | ✅                                   |
+| `cc_binary` (default linkstatic=1), incl. run via `sh_test`/`data` | ✅                                    | ❌ (no static asan runtime on macOS) |
+| Binary copied out of bazel-out / deployed                          | ❌                                    | ✅ (dylib travels in runfiles)       |
+| Remote execution / `--remote_download_minimal`                     | ❌                                    | ✅ for tests                         |
+| Mechanism                                                          | post-link `install_name_tool` surgery | Bazel's designed runtime-lib channel |
+| Non-sanitized builds affected                                      | no                                    | no (feature select-gated)            |
+| mbo asan suite                                                     | 74/74                                 | 73/74                                |
+
+The approaches are **complementary**: A covers static-mode binaries on local
+machines; B makes the runtime travel with tests (correct for remote execution
+and moved binaries) using the supported Bazel mechanism. They compose without
+interference — with both active, static-mode binaries resolve via A's rpath
+and dynamic-mode tests prefer the runfiles copy.
+
+## Outlook: libc++
+
+`static_link_cpp_runtimes` + `{static,dynamic}_runtime_lib` is the _designed_
+mechanism for shipping the C++ standard library runtime. On darwin this
+toolchain currently falls back to the SDK's libc++
+(`cc_toolchain_config.bzl`, "use the SDK's libc++ entirely") precisely because
+the toolchain's `libc++.dylib` has an unresolvable `@rpath` install name —
+the same root cause as the sanitizer issue. Unlike the sanitizers, **both**
+branches have real artifacts there (`libc++.a` / `libc++.dylib`), so extending
+this branch's wiring to the standard library would allow hermetic libc++ on
+macOS in both link modes. That is the natural follow-up.
+
+## Sharp edges / caveats
+
+- Combining sanitizers (`--features=asan --features=ubsan`) makes both
+  `config_setting`s match and the `select()` fail as ambiguous. This is
+  **pre-existing** (the `sanitizer_link_flags` select in
+  `cc_toolchain_config.bzl` has the same shape) and matches Clang's model
+  (one runtime per link), but the error message is obscure.
+- `extra_enabled_features` silently drops `cc_external_feature` references —
+  enabling a legacy feature requires the `implies` indirection used here.
+- Scope: hermetic (downloaded) toolchains only; `absolute_paths` /host
+  toolchains are unchanged by either approach.

--- a/docs/osx-sanitizer-runtime.md
+++ b/docs/osx-sanitizer-runtime.md
@@ -173,6 +173,16 @@ config_setting). They compose without interference — with both active,
 static-mode binaries resolve via A's rpath and dynamic-mode links prefer the
 runfiles copy.
 
+**Verified on branch `osx-sanitizer-combined`** (this branch + #767
+cherry-picked; the two touch disjoint files): **74/74** mbo asan tests pass
+with default consumer settings on macOS 26 / Apple Silicon / LLVM 22.1.7.
+Spot-checks confirm each mechanism handles its own case: the static-mode
+`cc_binary` (`mbo/file/glob`) carries only A's `@loader_path/.../external/...`
+rpath (no solib rpaths — B stays inactive in static mode), while `cc_test`
+binaries get B's solib rpaths with the dylib physically present in runfiles.
+One cell remains uncovered by the combination: static-mode binaries under
+remote execution still need the consumer-side `linkstatic = False`.
+
 ## Outlook: libc++
 
 `static_link_cpp_runtimes` + `{static,dynamic}_runtime_lib` is the _designed_

--- a/docs/osx-sanitizer-runtime.md
+++ b/docs/osx-sanitizer-runtime.md
@@ -103,7 +103,7 @@ Properties:
    darwin hermetic toolchains; the host toolchain finds its runtime at its
    absolute location.
 
-### Validation: 73/74 mbo asan tests pass
+### Validation: 73/74 mbo asan tests pass (74/74 with one consumer-side change)
 
 The resulting `cc_test` binary gets exactly the right structure — three
 `@loader_path` rpaths covering both execution contexts, plus the dylib
@@ -125,9 +125,21 @@ The **one failure** is structural, not a bug: `//mbo/file:glob_sh_test` is an
 `sh_test` that runs a `cc_binary` (`mbo/file/glob`) from its runfiles. The
 binary links in static mode (`linkstatic = 1` default) → takes the
 `static_runtime_lib` branch (empty — macOS has **no static asan runtime**) →
-keeps only Clang's cwd-relative rpath → `Abort trap: 6` at load. Approach A
-covers this case; approach B cannot, short of requiring `linkstatic = 0` on
-sanitized binaries.
+keeps only Clang's cwd-relative rpath → `Abort trap: 6` at load.
+
+That case **is fixable on the consumer side**: setting `linkstatic = False` on
+the `cc_binary` flips it into dynamic linking mode, and the full mechanism
+kicks in — verified: `glob_sh_test` **passes**, the binary gets the same three
+`@loader_path` solib rpaths as tests, and the dylib propagates into the
+`sh_test`'s runfiles through the data-dep runfiles merge (so this also holds
+for remote execution). Because the toolchain does not advertise
+`supports_dynamic_linker`, `linkstatic = False` does _not_ switch the deps to
+shared libraries — only the runtime-lib channel changes. The attribute accepts
+`select()`, so it can be scoped to sanitizer builds (e.g. on a `san`
+config_setting). No `no_san`-style tag is needed.
+
+Without that per-target change, approach A covers the default-`linkstatic`
+case instead.
 
 ## Side finding: LLVM 20.1.8 asan deadlocks at init on macOS 26
 
@@ -142,21 +154,24 @@ macOS asan on LLVM ≥ 21. Any macOS asan testing must use 21.1.8+/22.1.7.
 
 ## Comparison
 
-|                                                                    | A: wrapper rpath (#767)               | B: `dynamic_runtime_lib`             |
-| ------------------------------------------------------------------ | ------------------------------------- | ------------------------------------ |
-| `cc_test` (default linkstatic=0)                                   | ✅                                    | ✅                                   |
-| `cc_binary` (default linkstatic=1), incl. run via `sh_test`/`data` | ✅                                    | ❌ (no static asan runtime on macOS) |
-| Binary copied out of bazel-out / deployed                          | ❌                                    | ✅ (dylib travels in runfiles)       |
-| Remote execution / `--remote_download_minimal`                     | ❌                                    | ✅ for tests                         |
-| Mechanism                                                          | post-link `install_name_tool` surgery | Bazel's designed runtime-lib channel |
-| Non-sanitized builds affected                                      | no                                    | no (feature select-gated)            |
-| mbo asan suite                                                     | 74/74                                 | 73/74                                |
+|                                                                    | A: wrapper rpath (#767)               | B: `dynamic_runtime_lib`                                        |
+| ------------------------------------------------------------------ | ------------------------------------- | --------------------------------------------------------------- |
+| `cc_test` (default linkstatic=0)                                   | ✅                                    | ✅                                                              |
+| `cc_binary` (default linkstatic=1), incl. run via `sh_test`/`data` | ✅                                    | ⚠️ needs `linkstatic = False` (no static asan runtime on macOS) |
+| Binary copied out of bazel-out / deployed                          | ❌                                    | ✅ (dylib travels in runfiles)                                  |
+| Remote execution / `--remote_download_minimal`                     | ❌                                    | ✅ (dylib rides runfiles, incl. via `data` deps)                |
+| Mechanism                                                          | post-link `install_name_tool` surgery | Bazel's designed runtime-lib channel                            |
+| Non-sanitized builds affected                                      | no                                    | no (feature select-gated)                                       |
+| mbo asan suite                                                     | 74/74                                 | 73/74 (74/74 with `linkstatic = False` on the one binary)       |
 
 The approaches are **complementary**: A covers static-mode binaries on local
-machines; B makes the runtime travel with tests (correct for remote execution
-and moved binaries) using the supported Bazel mechanism. They compose without
-interference — with both active, static-mode binaries resolve via A's rpath
-and dynamic-mode tests prefer the runfiles copy.
+machines with no consumer changes; B makes the runtime travel with the binary
+(correct for remote execution and moved binaries) using the supported Bazel
+mechanism, and covers everything on its own once sanitized `cc_binary` targets
+set `linkstatic = False` (e.g. via a `select()` on a sanitizer
+config_setting). They compose without interference — with both active,
+static-mode binaries resolve via A's rpath and dynamic-mode links prefer the
+runfiles copy.
 
 ## Outlook: libc++
 

--- a/docs/osx-sanitizer-runtime.md
+++ b/docs/osx-sanitizer-runtime.md
@@ -154,15 +154,15 @@ macOS asan on LLVM ≥ 21. Any macOS asan testing must use 21.1.8+/22.1.7.
 
 ## Comparison
 
-|                                                                    | A: wrapper rpath (#767)               | B: `dynamic_runtime_lib`                                        |
-| ------------------------------------------------------------------ | ------------------------------------- | --------------------------------------------------------------- |
-| `cc_test` (default linkstatic=0)                                   | ✅                                    | ✅                                                              |
-| `cc_binary` (default linkstatic=1), incl. run via `sh_test`/`data` | ✅                                    | ⚠️ needs `linkstatic = False` (no static asan runtime on macOS) |
-| Binary copied out of bazel-out / deployed                          | ❌                                    | ✅ (dylib travels in runfiles)                                  |
-| Remote execution / `--remote_download_minimal`                     | ❌                                    | ✅ (dylib rides runfiles, incl. via `data` deps)                |
-| Mechanism                                                          | post-link `install_name_tool` surgery | Bazel's designed runtime-lib channel                            |
-| Non-sanitized builds affected                                      | no                                    | no (feature select-gated)                                       |
-| mbo asan suite                                                     | 74/74                                 | 73/74 (74/74 with `linkstatic = False` on the one binary)       |
+|                                                                    | A: wrapper rpath (#767)               | B: `dynamic_runtime_lib`                                        | A+B combined (`osx-sanitizer-combined`)                 |
+| ------------------------------------------------------------------ | ------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------- |
+| `cc_test` (default linkstatic=0)                                   | ✅                                    | ✅                                                              | ✅ (via B's runfiles dylib)                             |
+| `cc_binary` (default linkstatic=1), incl. run via `sh_test`/`data` | ✅                                    | ⚠️ needs `linkstatic = False` (no static asan runtime on macOS) | ✅ (via A's rpath)                                      |
+| Binary copied out of bazel-out / deployed                          | ❌                                    | ✅ (dylib travels in runfiles)                                  | ✅ dynamic-mode; static-mode needs `linkstatic = False` |
+| Remote execution / `--remote_download_minimal`                     | ❌                                    | ✅ (dylib rides runfiles, incl. via `data` deps)                | ✅ dynamic-mode; static-mode needs `linkstatic = False` |
+| Mechanism                                                          | post-link `install_name_tool` surgery | Bazel's designed runtime-lib channel                            | both, on disjoint files; no interference                |
+| Non-sanitized builds affected                                      | no                                    | no (feature select-gated)                                       | no                                                      |
+| mbo asan suite                                                     | 74/74                                 | 73/74 (74/74 with `linkstatic = False` on the one binary)       | 74/74 (default consumer settings)                       |
 
 The approaches are **complementary**: A covers static-mode binaries on local
 machines with no consumer changes; B makes the runtime travel with the binary

--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -155,6 +155,37 @@ filegroup(
     ),
 )
 
+# Sanitizer runtime dylibs on macOS. Unlike Linux (where the runtimes are
+# static archives linked into the binary), Clang on macOS links sanitized
+# binaries against `@rpath/libclang_rt.<san>_osx_dynamic.dylib`, so the dylib
+# must be locatable at runtime. These filegroups let the darwin cc_toolchain
+# expose the matching runtime as `dynamic_runtime_lib`, which Bazel links via
+# the solib directory and ships in the binary's runfiles. Empty on non-darwin
+# distributions.
+filegroup(
+    name = "libclang_rt-asan-darwin",
+    srcs = glob(
+        ["lib/clang/{LLVM_VERSION}/lib/darwin/libclang_rt.asan_osx_dynamic.dylib"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "libclang_rt-tsan-darwin",
+    srcs = glob(
+        ["lib/clang/{LLVM_VERSION}/lib/darwin/libclang_rt.tsan_osx_dynamic.dylib"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
+    name = "libclang_rt-ubsan-darwin",
+    srcs = glob(
+        ["lib/clang/{LLVM_VERSION}/lib/darwin/libclang_rt.ubsan_osx_dynamic.dylib"],
+        allow_empty = True,
+    ),
+)
+
 filegroup(
     name = "ar",
     srcs = ["bin/llvm-ar"],

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -878,6 +878,33 @@ def cc_toolchain_config(
         "//conditions:default": [],
     })
 
+    # On macOS the sanitizer runtimes are dynamic-only: Clang links sanitized
+    # binaries against `@rpath/libclang_rt.<san>_osx_dynamic.dylib`, which must
+    # be locatable when the binary runs from its runfiles (e.g. `bazel test`).
+    # The darwin cc_toolchain exposes the matching runtime dylib through
+    # `dynamic_runtime_lib` (see the BUILD template in internal/configure.bzl),
+    # but Bazel only consults that attribute when the `static_link_cpp_runtimes`
+    # feature is enabled. The stock feature is defined (disabled) inside
+    # unix_cc_toolchain_config and cannot be enabled there directly, so enable
+    # it transitively: a tiny always-empty feature that `implies` it, wired into
+    # `extra_enabled_features` only when a sanitizer feature is on (the same
+    # `--features`-matching config_settings as the flag augmentation above, so
+    # exec-configuration builds stay unaffected).
+    sanitizer_runtime_features = []
+    if target_os == "darwin":
+        cc_feature(
+            name = name + "_sanitizer_runtime_runfiles",
+            feature_name = name + "_sanitizer_runtime_runfiles",
+            implies = ["@rules_cc//cc/toolchains/features:static_link_cpp_runtimes"],
+        )
+        runfiles_feature_label = ":" + name + "_sanitizer_runtime_runfiles"
+        sanitizer_runtime_features = select({
+            str(Label("@toolchains_llvm//toolchain/config:use_asan")): [runfiles_feature_label],
+            str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [runfiles_feature_label],
+            str(Label("@toolchains_llvm//toolchain/config:use_tsan")): [runfiles_feature_label],
+            "//conditions:default": [],
+        })
+
     if compiler_configuration["extra_compile_flags"] != None:
         compile_flags.extend(_fmt_flags(compiler_configuration["extra_compile_flags"], toolchain_path_prefix))
     if compiler_configuration["extra_cxx_flags"] != None:
@@ -941,6 +968,6 @@ def cc_toolchain_config(
         coverage_link_flags = coverage_link_flags,
         supports_start_end_lib = supports_start_end_lib,
         builtin_sysroot = sysroot_path,
-        extra_enabled_features = nomsan_feature_labels + extra_enabled_features,
+        extra_enabled_features = nomsan_feature_labels + extra_enabled_features + sanitizer_runtime_features,
         extra_known_features = msan_feature_labels + extra_known_features,
     )

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -765,6 +765,8 @@ system_module_map(
     sysroot_path = "{sysroot_path}",
 )
 
+filegroup(name = "runtime-libs-empty-{suffix}", srcs = [])
+
 cc_toolchain(
     name = "cc-clang-{suffix}",
     all_files = "all-files-{suffix}",
@@ -777,7 +779,7 @@ cc_toolchain(
     strip_files = "strip-files-{suffix}",
     toolchain_config = "local-{suffix}",
     module_map = "module-{suffix}",
-    supports_header_parsing = True,
+    supports_header_parsing = True,{runtime_lib_attrs}
 )
 """
 
@@ -790,6 +792,34 @@ cc_toolchain(
         for dir in cxx_builtin_include_directories
         if _is_hermetic_or_exists(rctx, dir, sysroot_path)
     ]
+
+    # On macOS the sanitizer runtimes are dynamic-only and referenced as
+    # `@rpath/libclang_rt.<san>_osx_dynamic.dylib`, so the dylib must travel
+    # with sanitized binaries. Expose the matching runtime through
+    # `dynamic_runtime_lib`: Bazel links it via the solib directory (with an
+    # `@loader_path` rpath) and ships it in the binary's runfiles. Bazel only
+    # consults these attributes when the `static_link_cpp_runtimes` feature is
+    # enabled, which cc_toolchain_config.bzl arranges whenever a sanitizer
+    # feature is on. Scoped to the hermetic toolchain; the host toolchain's
+    # runtime is found at its absolute location. The computed text is passed as
+    # a format argument (not inlined in the template) so its select() braces
+    # are not re-interpreted by the outer format().
+    runtime_lib_attrs = ""
+    if target_os == "darwin" and not use_absolute_paths_llvm:
+        runtime_lib_attrs = """
+    static_runtime_lib = ":runtime-libs-empty-{suffix}",
+    dynamic_runtime_lib = select({{
+        "{use_asan}": "{root}:libclang_rt-asan-darwin",
+        "{use_ubsan}": "{root}:libclang_rt-ubsan-darwin",
+        "{use_tsan}": "{root}:libclang_rt-tsan-darwin",
+        "//conditions:default": ":runtime-libs-empty-{suffix}",
+    }}),""".format(
+            suffix = suffix,
+            root = target_toolchain_root,
+            use_asan = str(Label("//toolchain/config:use_asan")),
+            use_ubsan = str(Label("//toolchain/config:use_ubsan")),
+            use_tsan = str(Label("//toolchain/config:use_tsan")),
+        )
 
     return template.format(
         suffix = suffix,
@@ -852,6 +882,7 @@ cc_toolchain(
         extra_target_compatible_with_specific = toolchain_info.extra_target_compatible_with.get(target_pair, []),
         extra_exec_compatible_with_all_targets = toolchain_info.extra_exec_compatible_with.get("", []),
         extra_target_compatible_with_all_targets = toolchain_info.extra_target_compatible_with.get("", []),
+        runtime_lib_attrs = runtime_lib_attrs,
     )
 
 def _is_remote(rctx, exec_os, exec_arch):

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -226,3 +226,30 @@ for rpath in ${RPATHS}; do
     fi
   done
 done
+
+# Sanitizer runtimes (e.g. libclang_rt.asan_osx_dynamic.dylib) are linked with an
+# `@rpath/<name>` install name, and Clang adds a *toolchain-relative* LC_RPATH
+# (`external/.../lib/clang/<v>/lib/darwin`) that only resolves when the process's
+# working directory is the execroot -- true at link time, but not when a test
+# runs from its runfiles, so the dylib is "not loaded" at runtime. Add an
+# `@loader_path`-relative LC_RPATH to the toolchain's compiler-rt darwin dir so
+# `@rpath` resolves regardless of the working directory -- no absolute paths
+# (which break the sandbox) and no copying the dylib into runfiles. Only for the
+# hermetic (relative-prefix) toolchain; the host toolchain finds it normally.
+if [[ ${toolchain_path_prefix} != /* ]] && [[ -n ${OUTPUT} && ${OUTPUT} != "1" && -f ${OUTPUT} ]]; then
+  if /usr/bin/otool -L "${OUTPUT}" 2>/dev/null | grep -q '@rpath/libclang_rt\.'; then
+    output_dir="$(dirname_shim "${OUTPUT}")"
+    # One `../` per component of OUTPUT's dir climbs from `@loader_path` back to
+    # the execroot, which is also where `external/...` (the toolchain) lives.
+    loader_to_execroot=""
+    IFS='/' read -ra output_parts <<<"${output_dir}"
+    for _part in "${output_parts[@]}"; do
+      loader_to_execroot="../${loader_to_execroot}"
+    done
+    for darwin_dir in "${toolchain_path_prefix}"lib/clang/*/lib/darwin; do
+      [[ -d ${darwin_dir} ]] || continue
+      "${INSTALL_NAME_TOOL}" -add_rpath \
+        "@loader_path/${loader_to_execroot}${darwin_dir}" "${OUTPUT}" 2>/dev/null || true
+    done
+  fi
+fi


### PR DESCRIPTION
Combined fix for #192 on macOS: ship the sanitizer runtime dylibs through `cc_toolchain.dynamic_runtime_lib` (runfiles + solib `@loader_path` rpaths), composed with the post-link `@loader_path` rpath rewrite from #767.

**Stacked on #767** — this branch contains that PR's commit (`osx: load sanitizer runtime dylibs via @loader_path rpath`) plus the `dynamic_runtime_lib` mechanism. If #767 lands first, this rebases cleanly (the two touch disjoint files).

## Why both

On macOS the sanitizer runtimes are dynamic-only; sanitized binaries reference `@rpath/libclang_rt.<san>_osx_dynamic.dylib`, which is not locatable when a test runs from its runfiles. The two mechanisms cover complementary cases:

- **`dynamic_runtime_lib`** (this branch's new commits): Bazel links the runtime dylib via the solib directory with dyld-native `@loader_path` rpaths and ships it in the binary's runfiles. Correct for remote execution and binaries moved out of `bazel-out`, but only engages for dynamic-mode links (`cc_test` default; `cc_binary` needs `linkstatic = False` — macOS has no static asan runtime).
- **Wrapper rpath rewrite** (#767): covers static-mode links (`cc_binary` default, incl. run via `sh_test`/`data`) with no consumer changes, but is local-execution only.

Gating: `{static,dynamic}_runtime_lib` are only consulted when `static_link_cpp_runtimes` is enabled; a darwin-only `cc_feature` that *implies* `@rules_cc//cc/toolchains/features:static_link_cpp_runtimes` is wired into `extra_enabled_features` under a `select()` on the existing `use_{asan,ubsan,tsan}` config settings, so non-sanitizer and exec-configuration builds are unaffected.

## Validation

`helly25/mbo` asan suite (74 test targets), macOS 26 / Apple Silicon, LLVM 22.1.7, default consumer settings: **74/74 pass**. Spot-checks confirm each mechanism handles its own case (static-mode binary carries only the wrapper rpath; `cc_test` binaries get solib rpaths with the dylib physically in runfiles).

Full analysis, comparison table, and sharp edges in `docs/osx-sanitizer-runtime.md` (included in this PR).

Fixes #192
