### PR TITLE
configure: support TOOLCHAINS_LLVM_DISABLE_DATE_REDACTION env-var opt-out

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -224,13 +224,16 @@ def cc_toolchain_config(
     unfiltered_compile_flags = [
         # Do not resolve our symlinked resource prefixes to real paths.
         "-no-canonical-prefixes",
-        # Reproducibility: redact date macros via an -imacros header rather than
-        # -D__DATE__="redacted" on the command line, whose quotes are lost when
-        # passed through sub-build flag strings.
-        "-Wno-builtin-macro-redefined",
-        "-imacros",
-        redacted_dates_path,
     ]
+    if redacted_dates_path:
+        unfiltered_compile_flags += [
+            # Reproducibility: redact date macros via an -imacros header rather than
+            # -D__DATE__="redacted" on the command line, whose quotes are lost when
+            # passed through sub-build flag strings.
+            "-Wno-builtin-macro-redefined",
+            "-imacros",
+            redacted_dates_path,
+        ]
 
     major_llvm_version = int(llvm_version.split(".")[0])
 

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -838,7 +838,14 @@ cc_toolchain(
         target_toolchain_path_prefix = target_toolchain_path_prefix,
         tools_path_prefix = toolchain_info.tools_path_prefix,
         wrapper_bin_prefix = toolchain_info.wrapper_bin_prefix,
-        redacted_dates_path = "external/{}/redacted_dates.h".format(rctx.name),
+        # Env-var opt-out for consumers whose actions re-serialize toolchain
+        # flags into out-of-sandbox compiler invocations (rules_rust
+        # cargo_build_script with --strategy=CargoBuildScriptRun=local,
+        # rules_foreign_cc make/cmake). The sandbox-relative redacted_dates.h
+        # path cannot resolve outside the sandbox.
+        redacted_dates_path = (
+            "" if rctx.os.environ.get("TOOLCHAINS_LLVM_DISABLE_DATE_REDACTION", "") in ("1", "true", "True") else "external/{}/redacted_dates.h".format(rctx.name)
+        ),
         sysroot_label_str = sysroot_label_str,
         sysroot_path = sysroot_path,
         stdlib = stdlib,


### PR DESCRIPTION
Fixes #771.

## Problem

PR #756 injects `-imacros external/.../redacted_dates.h` into `unfiltered_compile_flags`. The path is sandbox-relative. That breaks any consumer whose actions re-serialize toolchain flags into out-of-sandbox compiler invocations:

- `rules_rust` `cargo_build_script` with `--strategy=CargoBuildScriptRun=local` (the recommended workaround for the `libtcmalloc-sys` sandbox-symlink issue, per rules_rust discussion). Every `-sys` crate that ships C source fails with `fatal error: '.../redacted_dates.h' file not found`.
- `rules_foreign_cc` make/cmake builds that embed compiler-flag strings — the original failure mode PR #756 was trying to fix; the new form has the analogous file-path-loss bug.

Reproducer + full context in #771.

## Fix

Smallest viable: env-var opt-out at toolchain configure time. `TOOLCHAINS_LLVM_DISABLE_DATE_REDACTION=1` (or `true`) → `redacted_dates_path` is emitted empty → the `-imacros` injection block is skipped in `unfiltered_compile_flags`.

**Default behavior unchanged.** Existing consumers see no impact.

## Why env var, not feature flag or attribute

- Module extension attribute would need plumbing through `extensions/llvm.bzl` + `internal/repo.bzl` + `internal/configure.bzl` — wider API surface.
- A Bazel `cc_feature` would mean a runtime feature toggle, but `unfiltered_compile_flags` is applied at toolchain config time in a different layer from the feature pipeline. Bigger refactor.
- Env var at `repository_ctx` time is exactly the right granularity — the decision happens once when the toolchain is configured.

## Alternatives considered

- **Absolute path via `rctx.path("redacted_dates.h")`** — bakes a machine-specific path into the cc_toolchain config; breaks remote execution cache.
- **Revert PR #756, restore `-D__DATE__="redacted"`** — trades one bug for another.
- **Propagate `cxx_builtin_include_files` to local-strategy cargo_build_script** — requires cooperation from rules_rust; out of scope here.

Happy to expand to a full feature-flag / module-attribute if maintainers prefer that shape.

## Files

- `toolchain/internal/configure.bzl` — read env var at repo rule time; emit empty path when opted-out.
- `toolchain/cc_toolchain_config.bzl` — guard the `-imacros`/`-Wno-builtin-macro-redefined` injection on `redacted_dates_path` being non-empty.

## Test plan

- [x] Default build unchanged (env var unset → original injection present).
- [x] With env var set, `bazel build` of a Rust target whose dep graph includes `ring` build script succeeds (verified locally on darwin-aarch64 + linux-x86_64 against `toolchains_llvm@332d6856`).
- [ ] CI matrix coverage — happy to add if maintainers want a regression test.