### PR TITLE
ci: publish to BCR via reusable workflow (replace retired app)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,43 @@
+# Publish a new release to the Bazel Central Registry (BCR).
+#
+# Called by release.yaml after a release is cut. Can also be run manually from
+# the GitHub Actions UI ("Run workflow") -- select the release tag as the ref
+# and it will (re)publish that tag, e.g. to retry a failed run.
+name: Publish to BCR
+
+on:
+  # Triggered from the release.yaml workflow after a successful release.
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+    secrets:
+      BCR_PUBLISH_TOKEN:
+        required: true
+  # Manual retry. No inputs: run it against the release tag as the ref.
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
+    with:
+      # No input on manual dispatch; fall back to the selected ref.
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      # Fork of bazelbuild/bazel-central-registry the PR branch is pushed to.
+      registry_fork: bazel-contrib/bazel-central-registry
+      # Open a normal (non-draft) PR so maintainers can review and merge it.
+      draft: false
+      # This repo uses a custom release workflow that does not emit SLSA
+      # attestations or upload the release archive as a workflow artifact, so
+      # disable both. publish-to-bcr computes the integrity by downloading the
+      # release tarball from the URL in .bcr/source.template.json.
+      attest: false
+      download_default_release_artifacts: false
+    secrets:
+      # Pushes the branch to the registry fork and opens the pull request.
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,14 @@ jobs:
           body_path: release_notes.txt
           files: toolchains_llvm-*.tar.gz
           fail_on_unmatched_files: true
+  # Mirror the release to the Bazel Central Registry. Replaces the retired
+  # publish-to-bcr GitHub App. See .github/workflows/publish.yaml.
+  publish:
+    needs: release
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag_name: ${{ github.ref_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
## What

Automates publishing to the Bazel Central Registry (BCR) from our own release pipeline, replacing the **publish-to-bcr GitHub App** which stopped firing for this repo (it silently missed v1.7.0 and v1.8.0, both published manually) and is **being discontinued after 2026-06-30**.

- Adds `.github/workflows/publish.yaml` — a thin wrapper around `bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1` (the same reusable workflow bazel-gazelle and other bazel-contrib repos use).
- `release.yml` now runs a `publish` job after `release` (`needs: release`) that calls it with the pushed tag.
- Workflow-level permission widened from `read-all` to `contents: write` so the reusable workflow can run.

It also supports **manual re-publish**: `workflow_dispatch` on *Publish to BCR* with a `tag_name`, so a failed/missed publish can be retried for any existing tag without re-releasing.

## Why `attest: false`

bazel-gazelle uses `attest: true`, but it releases via the shared `release_ruleset` workflow that uploads attestable artifacts. This repo uses a **custom** `release.yml` (`release_prep.sh` + `action-gh-release`) that emits no SLSA artifacts, so `attest: false` + `download_default_release_artifacts: false`. publish-to-bcr then computes the module integrity by downloading the released tarball from the URL in `.bcr/source.template.json` — exactly what the old app and the recent manual publishes did. Enabling attestations later would mean migrating to the `release_ruleset` flow (separate change).

## ⚠️ Prerequisite before this works

A **`BCR_PUBLISH_TOKEN`** secret must be available to this repo (org-level for `bazel-contrib`, or repo-level): a classic PAT with `repo` + `workflow` scopes that can push to `bazel-contrib/bazel-central-registry` and open PRs against `bazelbuild/bazel-central-registry`. The `bazel-contrib/bazel-central-registry` fork already exists and is what `registry_fork` points at. If the org secret bazel-gazelle uses is already shared to this repo, nothing else is needed.

## Testing

After merge + secret: cut a tag as usual, or `workflow_dispatch` *Publish to BCR* with an existing tag (e.g. `v1.8.0`) to confirm it opens a BCR PR. (1.8.0 is already in BCR, so a dispatch test would no-op/duplicate — better to validate on the next real release or a throwaway tag.)