### PR TITLE
Make date-macro redaction a toggleable feature (fixes #771)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ cc_binary(
 )
 ```
 
-```
+```text
 # Or per-config in .bazelrc.
 common --features=-date_redaction
 ```

--- a/README.md
+++ b/README.md
@@ -362,6 +362,46 @@ then they can be referenced as:
 - `@llvm_toolchain//:clang-format`
 - `@llvm_toolchain//:llvm-cov`
 
+### Date-macro redaction
+
+For reproducible builds the toolchain redacts the `__DATE__`, `__TIME__`, and
+`__TIMESTAMP__` preprocessor macros, replacing them with a constant. This is
+done by force-including a generated header with `-imacros`, which is wired
+through the `date_redaction` feature that is **enabled by default** — no
+configuration is needed for the common case.
+
+A small number of consumers re-serialize the toolchain's compile flags and run
+the compiler outside Bazel's sandbox — for example `rules_rust`
+`cargo_build_script` with `--strategy=CargoBuildScriptRun=local`, or some
+`rules_foreign_cc` make/cmake builds. There the sandbox-relative path of the
+force-included header cannot be resolved and the compile fails. For those cases
+the redaction can be turned off like any other Bazel feature, on a per-target,
+per-package, or global/`.bazelrc` basis:
+
+```sh
+# Disable globally (note the leading "-", which means "disable the feature").
+bazel build //... --features=-date_redaction
+```
+
+```python
+# Or disable for a single target.
+cc_binary(
+    name = "uses_local_cargo_build_script",
+    features = ["-date_redaction"],
+    # ...
+)
+```
+
+```
+# Or per-config in .bazelrc.
+common --features=-date_redaction
+```
+
+Disabling it only drops the redaction flags; nothing else about the toolchain
+changes. Note that build-tool (exec-configuration) actions reset `--features`
+to `--host_features`, so to also disable redaction for them use
+`--host_features=-date_redaction`.
+
 ### Strict header deps (Linux only)
 
 The toolchain supports Bazel's `layering_check` feature, which relies on

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load(":transitions.bzl", "dwp_file", "msan_flags_test", "sanitizer_test", "transition_library_to_platform")
+load(":transitions.bzl", "date_redaction_default_test", "date_redaction_disabled_test", "dwp_file", "msan_flags_test", "sanitizer_test", "transition_library_to_platform")
 
 cc_library(
     name = "stdlib",
@@ -120,6 +120,21 @@ msan_flags_test(
     name = "msan_flags_test",
     target_compatible_with = ["@platforms//os:linux"],
     target_under_test = ":stdlib_bin",
+)
+
+# Analysis-only checks for the date_redaction cc_feature (#771): redaction flags
+# are on the compile command by default, and `--features=-date_redaction` turns
+# them off. Cross-platform, so no target_compatible_with restriction.
+date_redaction_default_test(
+    name = "date_redaction_default_test",
+    target_under_test = ":stdlib_bin",
+    want_redaction = True,
+)
+
+date_redaction_disabled_test(
+    name = "date_redaction_disabled_test",
+    target_under_test = ":stdlib_bin",
+    want_redaction = False,
 )
 
 # End-to-end msan test. Built and run with the instrumented-libc++ toolchain

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -218,3 +218,56 @@ msan_flags_test = analysistest.make(
         "//command_line_option:features": ["msan"],
     },
 )
+
+def _date_redaction_flags_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    cpp_actions = [
+        a
+        for a in analysistest.target_actions(env)
+        if a.mnemonic == "CppCompile"
+    ]
+    asserts.true(env, len(cpp_actions) > 0, "expected a CppCompile action")
+    argv = cpp_actions[0].argv
+
+    # The date_redaction feature force-includes the generated redacted_dates.h
+    # via `-imacros`; that header path is the unambiguous on/off signal.
+    has_redaction = [a for a in argv if a.endswith("redacted_dates.h")]
+    if ctx.attr.want_redaction:
+        asserts.true(
+            env,
+            has_redaction,
+            "expected -imacros redacted_dates.h on the compile command line " +
+            "(date_redaction is enabled by default), got: %s" % argv,
+        )
+    else:
+        asserts.false(
+            env,
+            has_redaction,
+            "expected no redacted_dates.h on the compile command line with " +
+            "--features=-date_redaction, got: %s" % argv,
+        )
+    return analysistest.end(env)
+
+_date_redaction_attrs = {
+    "want_redaction": attr.bool(mandatory = True),
+}
+
+# Analysis-only test: the date_redaction cc_feature is enabled by default, so
+# the `-imacros redacted_dates.h` reproducibility flags must be on the compile
+# command line out of the box.
+date_redaction_default_test = analysistest.make(
+    _date_redaction_flags_test_impl,
+    attrs = _date_redaction_attrs,
+)
+
+# Same action, but with `--features=-date_redaction`: the redaction flags must
+# be gone. This guards the opt-out that consumers whose actions re-serialize
+# toolchain flags out of the sandbox (rules_rust cargo_build_script with
+# --strategy=CargoBuildScriptRun=local, rules_foreign_cc) rely on -- see #771.
+date_redaction_disabled_test = analysistest.make(
+    _date_redaction_flags_test_impl,
+    attrs = _date_redaction_attrs,
+    config_settings = {
+        "//command_line_option:features": ["-date_redaction"],
+    },
+)

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -224,9 +224,20 @@ def cc_toolchain_config(
     unfiltered_compile_flags = [
         # Do not resolve our symlinked resource prefixes to real paths.
         "-no-canonical-prefixes",
-        # Reproducibility: redact date macros via an -imacros header rather than
-        # -D__DATE__="redacted" on the command line, whose quotes are lost when
-        # passed through sub-build flag strings.
+    ]
+
+    # Reproducibility: redact the __DATE__/__TIME__/__TIMESTAMP__ macros via an
+    # -imacros header rather than -D__DATE__="redacted" on the command line,
+    # whose quotes are lost when passed through sub-build flag strings. These
+    # flags live in the `date_redaction` cc_feature (enabled by default, see
+    # below) rather than the always-on unfiltered_compile_flags so consumers
+    # can disable them with `--features=-date_redaction` (e.g. in .bazelrc) or
+    # `features = ["-date_redaction"]`. This is needed by actions that
+    # re-serialize the toolchain's compile flags into out-of-sandbox compiler
+    # invocations -- rules_rust `cargo_build_script` with
+    # `--strategy=CargoBuildScriptRun=local`, rules_foreign_cc make/cmake --
+    # where the sandbox-relative redacted_dates.h path cannot resolve (#771).
+    date_redaction_flags = [
         "-Wno-builtin-macro-redefined",
         "-imacros",
         redacted_dates_path,
@@ -928,6 +939,24 @@ def cc_toolchain_config(
     if compiler_configuration["extra_unfiltered_compile_flags"] != None:
         unfiltered_compile_flags.extend(_fmt_flags(compiler_configuration["extra_unfiltered_compile_flags"], toolchain_path_prefix))
 
+    # Date-macro redaction (see date_redaction_flags above). Carried by a
+    # cc_feature that is enabled by default (wired through extra_enabled_features
+    # below), so the redaction applies unchanged out of the box but can be turned
+    # off per-config with `--features=-date_redaction` or per-target with
+    # `features = ["-date_redaction"]`. cc_feature rules always declare the
+    # feature disabled; the default-enabled state comes from extra_enabled_features.
+    cc_args(
+        name = name + "_date_redaction_args",
+        actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+        args = date_redaction_flags,
+    )
+    cc_feature(
+        name = name + "_date_redaction",
+        feature_name = "date_redaction",
+        args = [":" + name + "_date_redaction_args"],
+    )
+    date_redaction_feature_labels = [":" + name + "_date_redaction"]
+
     # Source: https://cs.opensource.google/bazel/bazel/+/master:tools/cpp/unix_cc_toolchain_config.bzl
     unix_cc_toolchain_config(
         name = name,
@@ -968,6 +997,6 @@ def cc_toolchain_config(
         coverage_link_flags = coverage_link_flags,
         supports_start_end_lib = supports_start_end_lib,
         builtin_sysroot = sysroot_path,
-        extra_enabled_features = nomsan_feature_labels + extra_enabled_features + sanitizer_runtime_features,
+        extra_enabled_features = nomsan_feature_labels + date_redaction_feature_labels + extra_enabled_features + sanitizer_runtime_features,
         extra_known_features = msan_feature_labels + extra_known_features,
     )


### PR DESCRIPTION
## Problem

PR #756 (shipped in **v1.8.0**) redacts `__DATE__`/`__TIME__`/`__TIMESTAMP__` for reproducibility by force-including a generated `redacted_dates.h` via `-imacros`, placed in the always-on `unfiltered_compile_flags`. The header path is **sandbox-relative**, so any consumer that re-serializes the toolchain's compile flags and runs the compiler **outside** Bazel's sandbox fails with `fatal error: '.../redacted_dates.h' file not found`:

- `rules_rust` `cargo_build_script` with `--strategy=CargoBuildScriptRun=local` (every `*-sys` crate that ships C source)
- some `rules_foreign_cc` make/cmake builds

This is a regression for anyone upgrading past v1.7.0. See #771.

## Approach

As noted on #771, the root cause is in the consumers (they leave the sandbox), so this repo's job is to offer a clean, **configurable** opt-out — not the all-or-nothing env-var of #772. Per the discussion (control via `.bazelrc`, gate behind a feature), this exposes the redaction as a standard Bazel **`date_redaction` feature, enabled by default** so behavior is unchanged out of the box.

The `-Wno-builtin-macro-redefined` / `-imacros redacted_dates.h` flags move out of the baked `unfiltered_compile_flags` into a `cc_args` + `cc_feature` wired on via `extra_enabled_features` — modeled on the existing msan/nomsan `cc_feature` pattern in the same file.

Consumers that need it disable it like any other feature:

```sh
bazel build //... --features=-date_redaction       # global
```
```python
cc_binary(name = "x", features = ["-date_redaction"])  # per-target
```
```
common --features=-date_redaction                   # .bazelrc
```

(Build-tool/exec-config actions reset `--features` to `--host_features`, so `--host_features=-date_redaction` covers those — documented in the README.)

## Tests

Two analysis-only tests (modeled on `msan_flags_test`):

- `date_redaction_default_test` — asserts `redacted_dates.h` is on the `CppCompile` command line by default.
- `date_redaction_disabled_test` — asserts it is **absent** under `--features=-date_redaction`.

Verified locally (darwin-arm64, LLVM 19.1.7): `aquery` shows the flags present by default and gone with the feature disabled; both new tests and the existing `stdlib_test` pass; buildifier clean.

## Files

- `toolchain/cc_toolchain_config.bzl` — `date_redaction` cc_feature (default-on).
- `tests/transitions.bzl`, `tests/BUILD.bazel` — regression tests.
- `README.md` — "Date-macro redaction" section.

Fixes #771. Supersedes the env-var approach in #772.