### PR TITLE
feat(toolchain): add clang_cpp library for embedding libclang-cpp

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,6 +163,27 @@ jobs:
         env:
           USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_tests.sh -t @llvm_toolchain_with_system_llvm//:cc-toolchain-x86_64-linux -v 16.0.0
+  clang_cpp_test:
+    # Builds and runs //:clang_cpp_test, which compiles against the Clang/LLVM
+    # development headers and links libclang-cpp via the
+    # @llvm_toolchain_llvm//:clang_cpp target. libclang-cpp is only shipped by
+    # some distributions, so this runs against the default (modern) toolchain on
+    # Ubuntu and macOS with the latest Bazel only.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        bzlmod: [true, false]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: tests/scripts/ubuntu_install_libtinfo.sh
+      - name: Test
+        env:
+          USE_BAZEL_VERSION: latest
+          USE_BZLMOD: ${{ matrix.bzlmod }}
+        run: tests/scripts/run_clang_cpp_test.sh
   msan_test:
     # End-to-end MemorySanitizer test. Downloads a full clang + an
     # instrumented-libc++ overlay and builds/runs an msan binary, exercising the
@@ -201,6 +222,7 @@ jobs:
       - xcompile_test
       - abs_paths_test
       - sys_paths_test
+      - clang_cpp_test
       - msan_test
     if: always()
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -348,6 +348,17 @@ repo with the suffix `_llvm` appended to the name you used for the
 `llvm_toolchain` rule. For example, `@llvm_toolchain_llvm//:bin/clang-format`
 is a valid and visible target in the quickstart example above.
 
+The distribution also exposes `@llvm_toolchain_llvm//:clang_cpp`, a `cc_library`
+that links libclang-cpp (Clang's C++ API, which statically embeds LLVM) together
+with the Clang/LLVM development headers, for tools that embed Clang in-process
+(e.g. dependency scanning or clang-tidy-style tooling). Because LLVM is built
+without RTTI, dependents deriving from Clang's polymorphic types must compile
+with `-fno-rtti`. Note the C++ standard library: the upstream LLVM **Linux**
+releases are built against libstdc++, so a dependent must be built with a
+libstdc++ standard library (`stdlib = "stdc++"` or `"dynamic-stdc++"`) -- a
+libc++ dependent (the default) fails to link against it with `undefined symbol`.
+macOS releases are built against libc++, matching the default.
+
 When using the `toolchain_roots` attribute, there is currently no single target
 that you can reference, and you may have to alias the tools you want with a
 `select` clause in your workspace.

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -232,6 +232,25 @@ sh_test(
     ],
 )
 
+# Verifies the `clang_cpp` target: compiles against the Clang/LLVM development
+# headers and links libclang-cpp (which statically embeds LLVM). Compiled with
+# `-fno-rtti` because the LLVM distribution is built without RTTI.
+#
+# Tagged `manual` so the default `bazel test //...` / `//:all` does not pick it
+# up: libclang-cpp is only shipped by some distributions, so the target is empty
+# on others (e.g. the pinned LLVM 13.0.0 used by the container tests) and would
+# fail to link. The `clang_cpp_test` CI job (run_clang_cpp_test.sh) runs it
+# explicitly in `-c opt` against the default (modern) toolchain on Ubuntu and
+# macOS, mirroring the opt/host-opt configuration clang_cpp is consumed in.
+cc_test(
+    name = "clang_cpp_test",
+    srcs = ["clang_cpp_test.cc"],
+    copts = ["-fno-rtti"],
+    linkstatic = True,
+    tags = ["manual"],
+    deps = ["@llvm_toolchain_llvm//:clang_cpp"],
+)
+
 # As a workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/1018.
 toolchain(
     name = "ninja_mac_arm64_toolchain",

--- a/tests/clang_cpp_test.cc
+++ b/tests/clang_cpp_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2024 The Bazel Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Exercises the `@llvm_toolchain_llvm//:clang_cpp` target: it must be possible
+// to include the Clang/LLVM development headers and link against libclang-cpp
+// (which statically embeds LLVM). We pull in a symbol that is defined inside
+// libclang-cpp -- `clang::getClangFullVersion()` -- so the test fails to link
+// if the shared library is missing from the target, and fails to compile if the
+// headers are not exposed.
+
+#include <cstdio>
+#include <string>
+
+#include "clang/Basic/Version.h"
+
+int main() {
+  const std::string version = clang::getClangFullVersion();
+  std::printf("clang version: %s\n", version.c_str());
+  // The version string embeds the LLVM release, so it is never empty when the
+  // symbol resolved against the real libclang-cpp.
+  return version.empty() ? 1 : 0;
+}

--- a/tests/scripts/run_clang_cpp_test.sh
+++ b/tests/scripts/run_clang_cpp_test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Copyright 2024 The Bazel Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds and runs //:clang_cpp_test, exercising the
+# `@llvm_toolchain_llvm//:clang_cpp` target by compiling against the Clang/LLVM
+# development headers and linking libclang-cpp.
+#
+# Built in `-c opt`: clang_cpp is expected to be consumed only in opt (or
+# host-opt) configuration, so the test mirrors that.
+#
+# C++ standard library: the upstream LLVM *Linux* release is built against
+# libstdc++ (its libclang-cpp.so exports e.g. the cxx11-ABI-tagged
+# `getClangFullVersion[abi:cxx11]`), so a consumer built with libc++ -- the
+# toolchains_llvm default -- fails to link with `undefined symbol`. We therefore
+# build the test against libstdc++ on Linux via the dynamic-stdc++ toolchain
+# (libclang-cpp.so itself pulls libstdc++.so.6, so a shared libstdc++ matches).
+# macOS ships a libc++-built libclang-cpp.dylib, so the default toolchain works.
+#
+# The target is tagged `manual` (libclang-cpp is not shipped by every LLVM
+# distribution), so it is run explicitly here rather than via `//:all`. Only run
+# on Ubuntu and macOS with the latest Bazel; older toolchains/distributions are
+# not guaranteed to ship libclang-cpp.
+
+set -euo pipefail
+
+while getopts "h" opt; do
+  case "${opt}" in
+  "h")
+    echo "Usage: No options"
+    exit 2
+    ;;
+  *)
+    echo "invalid option: -${OPTARG}"
+    exit 1
+    ;;
+  esac
+done
+
+# On Linux, match the libstdc++ ABI of the prebuilt libclang-cpp by selecting
+# the dynamic-stdc++ toolchain. On macOS the default (libc++) toolchain matches.
+toolchain_name=""
+host_os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+if [[ "${host_os}" != "darwin" ]]; then
+  host_arch="$(uname -m)"
+  if [[ "${host_arch}" == "aarch64" ]] || [[ "${host_arch}" == "arm64" ]]; then
+    host_arch="aarch64"
+  fi
+  toolchain_name="@llvm_toolchain_dynamic_stdcpp//:cc-toolchain-${host_arch}-linux"
+fi
+
+scripts_dir="$(dirname "${BASH_SOURCE[0]}")"
+source "${scripts_dir}/bazel.sh"
+"${bazel}" version
+
+if [[ -n "${toolchain_name}" ]]; then
+  common_test_args+=("--extra_toolchains=${toolchain_name}")
+fi
+
+cd "${scripts_dir}"
+
+set -x
+"${bazel}" ${TEST_MIGRATION:+"--strict"} test \
+  "${common_test_args[@]}" \
+  --compilation_mode=opt \
+  --verbose_failures \
+  -- //:clang_cpp_test

--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 # Some targets may need to directly depend on these files.
@@ -268,4 +270,50 @@ filegroup(
         ],
         allow_empty = True,
     ),
+)
+
+# Clang's C++ API as a linkable shared library (libclang-cpp, which statically
+# embeds LLVM) together with the LLVM/Clang development headers, for tools that
+# embed clang in-process (e.g. dependency scanning, clang-tidy-style tooling).
+# Empty on distributions that ship no libclang-cpp. Headers are exposed via
+# `includes` (i.e. `-isystem`); the layering_check and parse_headers features
+# are disabled because LLVM's headers are not standalone-parseable and form one
+# large layer. Note: LLVM is built without RTTI, so dependents that derive from
+# clang's polymorphic types must compile with `-fno-rtti`.
+#
+# C++ standard library: the upstream LLVM *Linux* releases are built against
+# libstdc++, so libclang-cpp.so exports cxx11-ABI-tagged symbols. A dependent
+# built with libc++ (the toolchains_llvm default) fails to link against it
+# (`undefined symbol`); on Linux, build dependents with a libstdc++ stdlib
+# (`stdlib = "stdc++"` / `"dynamic-stdc++"`). macOS releases are built against
+# libc++, matching the default.
+cc_library(
+    name = "clang_cpp",
+    # On Linux libclang-cpp ships as a versioned shared object alongside an
+    # unversioned symlink (e.g. `libclang-cpp.so` -> `libclang-cpp.so.19.1`).
+    # Match only the versioned real file: globbing `libclang-cpp.so*` would pull
+    # in BOTH the symlink and its target as two separate precompiled libraries
+    # for the same library, which fails to link (`undefined symbol`). macOS
+    # ships a single unversioned `libclang-cpp.dylib`.
+    srcs = glob(
+        [
+            "lib/libclang-cpp.dylib",
+            "lib/libclang-cpp.so.*",
+        ],
+        allow_empty = True,
+    ),
+    hdrs = glob(
+        [
+            "include/clang/**",
+            "include/clang-c/**",
+            "include/llvm/**",
+            "include/llvm-c/**",
+        ],
+        allow_empty = True,
+    ),
+    features = [
+        "-layering_check",
+        "-parse_headers",
+    ],
+    includes = ["include"],
 )


### PR DESCRIPTION
Adds a `clang_cpp` cc_library which allows to develop tools directly on top of the LLVM libraries. Concretely you can write tools that directly interface with say clang-format implementation details or the clangd index.

# AG;DR

## What

Adds a `clang_cpp` cc_library to the LLVM distribution repo (`toolchain/BUILD.llvm_repo.tpl`) exposing **libclang-cpp** (Clang's C++ API, which statically embeds LLVM) together with the Clang/LLVM development headers, for tools that embed Clang in-process (e.g. dependency scanning, clang-tidy-style tooling). Empty on distributions that ship no libclang-cpp. LLVM is built without RTTI, so dependents deriving from Clang's polymorphic types must compile with `-fno-rtti`.

The `srcs` glob matches the versioned real file (`libclang-cpp.so.*`), not `libclang-cpp.so*`, which would also pull in the unversioned symlink as a second precompiled lib for the same library. macOS ships a single unversioned `libclang-cpp.dylib`.

## C++ standard library (Linux)

The upstream LLVM **Linux** releases are built against **libstdc++**, so `libclang-cpp.so` exports cxx11-ABI-tagged symbols (e.g. `clang::getClangFullVersion[abi:cxx11]`). A dependent compiled with **libc++ — the toolchains_llvm default — fails to link** against it with `undefined symbol`. So `clang_cpp` consumers on Linux must build with a libstdc++ standard library (`stdlib = "stdc++"` or `"dynamic-stdc++"`); macOS releases are built against libc++, matching the default. This is documented on the target and in the README "Accessing tools" section.

Ideally the target would declare this so misuse surfaces as an "incompatible target" rather than a link error, but there is no stdlib constraint to gate on today (`stdlib` is a toolchain-definition attribute, not a platform constraint). A `cxx_stdlib` `constraint_setting` wired through the toolchains is a reasonable follow-up; for now the requirement is documented.

## Test

- `tests/clang_cpp_test.cc` compiles against the headers and links a libclang-cpp symbol (`clang::getClangFullVersion()`) — fails if either the headers or the shared library are missing from the target.
- `//:clang_cpp_test` is tagged `manual` so it stays out of `//:all` (libclang-cpp is absent on some distributions, e.g. the pinned LLVM 13.0.0 used by the container tests).
- A dedicated `clang_cpp_test` CI job (`tests/scripts/run_clang_cpp_test.sh`) runs it in `-c opt` on Ubuntu and macOS with the latest Bazel — building against the `dynamic-stdc++` toolchain on Linux (to match the prebuilt lib's ABI) and the default toolchain on macOS. Wired into the `required_checks_done` gate.

## Notes

- Intentionally minimal: changes no existing job. Broader multi-version / per-arch CI coverage is a separate follow-up.
