### PR TITLE
Add install-name-tool to llvm repo

### DIFF
--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -225,6 +225,11 @@ filegroup(
 )
 
 filegroup(
+    name = "install-name-tool",
+    srcs = ["bin/llvm-install-name-tool"],
+)
+
+filegroup(
     name = "ranlib",
     srcs = ["bin/llvm-ranlib"],
 )


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/toolchains_llvm/issues/606.

This makes [llvm-install-name-tool](https://llvm.org/docs/CommandGuide/llvm-install-name-tool.html) available under `<name>_llvm//:install-name-tool`, making it available as a (hermetic) replacement for host install-name-tool.