### PR TITLE
fix(toolchain): drop redundant -stdlib=libc++ that clang reports unused

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load(":transitions.bzl", "dwp_file", "msan_flags_test", "sanitizer_test", "transition_library_to_platform")
+load(":transitions.bzl", "dwp_file", "msan_flags_test", "sanitizer_test", "stdlib_flags_test", "transition_library_to_platform")
 
 cc_library(
     name = "stdlib",
@@ -120,6 +120,15 @@ msan_flags_test(
     name = "msan_flags_test",
     target_compatible_with = ["@platforms//os:linux"],
     target_under_test = ":stdlib_bin",
+)
+
+# Verifies the default (builtin-libc++) toolchain locates libc++ via
+# -nostdinc++/-cxx-isystem and does NOT pass a redundant -stdlib=libc++, which
+# clang reports as -Wunused-command-line-argument on every object file. Runs on
+# both Linux and macOS (builtin-libc++ emits -nostdinc++ on each).
+stdlib_flags_test(
+    name = "stdlib_flags_test",
+    target_under_test = ":stdlib",
 )
 
 # End-to-end msan test. Built and run with the instrumented-libc++ toolchain

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -122,10 +122,11 @@ msan_flags_test(
     target_under_test = ":stdlib_bin",
 )
 
-# Verifies the default (builtin-libc++) toolchain locates libc++ via
-# -nostdinc++/-cxx-isystem and does NOT pass a redundant -stdlib=libc++, which
-# clang reports as -Wunused-command-line-argument on every object file. Runs on
-# both Linux and macOS (builtin-libc++ emits -nostdinc++ on each).
+# Verifies the C++ compile command line never carries both -stdlib=libc++ and
+# -nostdinc++ -- the redundant combination that makes clang emit
+# -Wunused-command-line-argument on every object file. Toolchain-agnostic, so it
+# is correct under //:all across the default builtin-libc++ toolchain and the
+# stdc++/sysroot toolchains the container tests select, on Linux and macOS.
 stdlib_flags_test(
     name = "stdlib_flags_test",
     target_under_test = ":stdlib",

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -218,3 +218,39 @@ msan_flags_test = analysistest.make(
         "//command_line_option:features": ["msan"],
     },
 )
+
+def _stdlib_flags_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    cpp_actions = [
+        a
+        for a in analysistest.target_actions(env)
+        if a.mnemonic == "CppCompile"
+    ]
+    asserts.true(env, len(cpp_actions) > 0, "expected a CppCompile action")
+    argv = cpp_actions[0].argv
+
+    # The libc++ headers are located explicitly via -nostdinc++ plus
+    # -cxx-isystem entries (see _cxx_isystem in cc_toolchain_config.bzl).
+    asserts.true(
+        env,
+        "-nostdinc++" in argv,
+        "expected -nostdinc++ on the compile command line, got: %s" % argv,
+    )
+
+    # Because -nostdinc++ overrides the C++ header search, -stdlib=libc++ has no
+    # compile-time effect and must NOT be passed: clang would report it unused,
+    # printing -Wunused-command-line-argument on every object file. Guards the
+    # regression fixed by dropping -stdlib=libc++ from the libc++ branches.
+    asserts.true(
+        env,
+        "-stdlib=libc++" not in argv,
+        "-stdlib=libc++ must not be on the compile command line (it is unused " +
+        "under -nostdinc++ and warns), got: %s" % argv,
+    )
+    return analysistest.end(env)
+
+# Analysis-only test: with the default builtin-libc++ toolchain, the C++ compile
+# action must locate libc++ via -nostdinc++/-cxx-isystem and must not carry a
+# redundant -stdlib=libc++ (which triggers -Wunused-command-line-argument). Runs
+# on Linux and macOS (builtin-libc++ emits -nostdinc++ on both).
+stdlib_flags_test = analysistest.make(_stdlib_flags_test_impl)

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -229,28 +229,26 @@ def _stdlib_flags_test_impl(ctx):
     asserts.true(env, len(cpp_actions) > 0, "expected a CppCompile action")
     argv = cpp_actions[0].argv
 
-    # The libc++ headers are located explicitly via -nostdinc++ plus
-    # -cxx-isystem entries (see _cxx_isystem in cc_toolchain_config.bzl).
+    # -stdlib=libc++ only steers the C++ header search at compile time, so it is
+    # unused -- and warns, -Wunused-command-line-argument, once per object --
+    # whenever -nostdinc++ overrides that search. The two must therefore never
+    # appear together on a compile command line. This invariant is
+    # toolchain-agnostic, so the test is correct under whatever toolchain the
+    # surrounding build selects: the libc++ configs no longer emit -stdlib=libc++
+    # (the fix), builtin-libc++ emits -nostdinc++ but not -stdlib=libc++, and the
+    # stdc++/sysroot toolchains (exercised by container tests) never emit
+    # -stdlib=libc++ at all.
     asserts.true(
         env,
-        "-nostdinc++" in argv,
-        "expected -nostdinc++ on the compile command line, got: %s" % argv,
-    )
-
-    # Because -nostdinc++ overrides the C++ header search, -stdlib=libc++ has no
-    # compile-time effect and must NOT be passed: clang would report it unused,
-    # printing -Wunused-command-line-argument on every object file. Guards the
-    # regression fixed by dropping -stdlib=libc++ from the libc++ branches.
-    asserts.true(
-        env,
-        "-stdlib=libc++" not in argv,
-        "-stdlib=libc++ must not be on the compile command line (it is unused " +
+        not ("-stdlib=libc++" in argv and "-nostdinc++" in argv),
+        "-stdlib=libc++ must not appear together with -nostdinc++ (it is unused " +
         "under -nostdinc++ and warns), got: %s" % argv,
     )
     return analysistest.end(env)
 
-# Analysis-only test: with the default builtin-libc++ toolchain, the C++ compile
-# action must locate libc++ via -nostdinc++/-cxx-isystem and must not carry a
-# redundant -stdlib=libc++ (which triggers -Wunused-command-line-argument). Runs
-# on Linux and macOS (builtin-libc++ emits -nostdinc++ on both).
+# Analysis-only test: the C++ compile command line must never carry both
+# -stdlib=libc++ and -nostdinc++ (the redundant-flag combination that triggers
+# -Wunused-command-line-argument). Toolchain-agnostic, so it is safe under
+# //:all across the default builtin-libc++ toolchain and the stdc++/sysroot
+# toolchains used by the container tests, on Linux and macOS.
 stdlib_flags_test = analysistest.make(_stdlib_flags_test_impl)

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -451,9 +451,12 @@ def cc_toolchain_config(
         stdlib = "stdc++-" + stdlib[len("dynamic-stdc++-"):]
 
     if stdlib == "builtin-libc++":
-        cxx_flags.extend([
-            "-stdlib=libc++",
-        ])
+        # NB: -stdlib=libc++ is intentionally NOT passed. It is only a
+        # compile-time header-selection flag (cxx_flags never reach the link
+        # action; libc++ is linked explicitly below), and the libc++ headers are
+        # already located explicitly via -nostdinc++ + -cxx-isystem (see
+        # cpp_system_includes / _cxx_isystem). Passing it therefore has no effect
+        # and triggers -Wunused-command-line-argument on every object file.
         system_includes.append(toolchain_builtin_include)
         if is_darwin_exec_and_target:
             # On macOS, use the SDK's libc++ entirely (headers + linking).
@@ -511,10 +514,10 @@ def cc_toolchain_config(
             ]
 
     elif stdlib == "libc++":
-        cxx_flags.extend([
-            "-stdlib=libc++",
-        ])
-
+        # As in the builtin-libc++ branch, -stdlib=libc++ is redundant: libc++ is
+        # located via -nostdinc++/-cxx-isystem and linked explicitly below, and
+        # on darwin (where -nostdinc++ is not emitted) clang already defaults to
+        # libc++. Passing it only produces -Wunused-command-line-argument.
         stdlib_link_libs.extend([
             "-l:libc++.a",
             "-l:libc++abi.a",


### PR DESCRIPTION
## Problem

Since #748 reworked libc++ header handling, the toolchain locates the libc++ headers explicitly via `-nostdinc++` + `-cxx-isystem`. With `-nostdinc++` on the compile line, `-stdlib=libc++` no longer affects header selection, and since it never reaches the link action (`cxx_flags` feed compile actions only), it is entirely unused — clang reports it once per object file:

```
clang: warning: argument unused during compilation: '-stdlib=libc++' [-Wunused-command-line-argument]
```

## Fix

Remove `-stdlib=libc++` from the `builtin-libc++` and `libc++` branches entirely, rather than conditionally guarding it (cf. #781). It is redundant in every configuration:

- Wherever `-nostdinc++` is emitted (builtin-libc++ on Linux and macOS, libc++ on Linux) it has no compile-time effect.
- On darwin `libc++` (the one config without `-nostdinc++`) clang already defaults to libc++.
- libc++ is linked explicitly via `-l:libc++.a` / `-l:libc++abi.a` (Linux) or `-lc++` / `-lc++abi` (Darwin); `-stdlib` never reaches the link action.

This is an alternative to #781: rather than guarding a redundant flag, it removes the flag at the source.

### Why not also add `-nostdlib++` (#532)?

#532 additionally suggests emitting `-nostdlib++` so a program can never link both libc++ and libstdc++. I checked empirically (LLVM 19.1.7, Linux): the prebuilt binaries do **not** double-link libstdc++ — no `libstdc++` in the binary's dynamic `NEEDED` in either `-c opt` or fastbuild. That concern does not manifest in this toolchain, so adding `-nostdlib++` would be churn without a correctness benefit. Left out of scope.

## Test

Adds `//:stdlib_flags_test`, an analysis-only test asserting the C++ compile command line carries `-nostdinc++` and **not** `-stdlib=libc++`. It introspects the `CppCompile` action's `argv` (like the existing `msan_flags_test`) and runs as part of `//:all` — i.e. the `test` CI job on Ubuntu and macOS, across every Bazel version and bzlmod setting.

## Validation

Verified on macOS (arm64) and Linux (arm64 container):

- `stdlib_flags_test` passes on both.
- A fresh C++ compile no longer emits the warning.
- libc++ programs build and run.
- The untouched `stdc++` path still builds and runs on Linux. (`stdc++` is unsupported on macOS — no system libstdc++, already excluded from the CI matrix — and is unchanged by this PR.)

Refs #781, #748, #532.
