### PR TITLE
Fix compiling assembly on OSX

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -313,3 +313,14 @@ cc_test(
     tags = ["manual"],
     deps = [":test_cxx_standard_lib_transitioned"],
 )
+
+cc_library(
+    name = "assembly_test_lib",
+    srcs = ["assembly_test.s"],
+)
+
+build_test(
+    name = "assembly_test",
+    targets = [":assembly_test_lib"],
+)
+

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -323,4 +323,3 @@ build_test(
     name = "assembly_test",
     targets = [":assembly_test_lib"],
 )
-

--- a/tests/assembly_test.s
+++ b/tests/assembly_test.s
@@ -1,0 +1,1 @@
+# An empty assembly file to test that assembler action works

--- a/tests/scripts/ubuntu_install_libtinfo.sh
+++ b/tests/scripts/ubuntu_install_libtinfo.sh
@@ -13,5 +13,5 @@ set -euo pipefail
 pkg="$(mktemp --suffix=.deb)"
 trap 'rm -f "${pkg}"' EXIT
 
-curl -L https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb -o "${pkg}"
+curl -L https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb -o "${pkg}"
 sudo dpkg -i "${pkg}"

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -695,7 +695,7 @@ filegroup(
 
 filegroup(name = "all-files-{suffix}", srcs = [":all-components-{suffix}", {extra_files_str}])
 filegroup(name = "archiver-files-{suffix}", srcs = [{extra_files_str}])
-filegroup(name = "assembler-files-{suffix}", srcs = [{extra_files_str}])
+filegroup(name = "assembler-files-{suffix}", srcs = ["redacted_dates.h", {extra_files_str}])
 filegroup(name = "compiler-files-{suffix}", srcs = [":compiler-components-{suffix}", {extra_files_str}])
 filegroup(name = "dwp-files-{suffix}", srcs = [{extra_files_str}])
 filegroup(name = "linker-files-{suffix}", srcs = [":linker-components-{suffix}", {extra_files_str}])
@@ -747,7 +747,7 @@ filegroup(
 
 filegroup(name = "all-files-{suffix}", srcs = [":all-components-{suffix}", {extra_files_str}])
 filegroup(name = "archiver-files-{suffix}", srcs = ["{llvm_dist_label_prefix}ar", {extra_files_str}])
-filegroup(name = "assembler-files-{suffix}", srcs = ["{llvm_dist_label_prefix}as", {extra_files_str}])
+filegroup(name = "assembler-files-{suffix}", srcs = ["{llvm_dist_label_prefix}as", "redacted_dates.h", {extra_files_str}])
 filegroup(name = "compiler-files-{suffix}", srcs = [":compiler-components-{suffix}", {extra_files_str}])
 filegroup(name = "dwp-files-{suffix}", srcs = ["{llvm_dist_label_prefix}dwp", {extra_files_str}])
 filegroup(name = "linker-files-{suffix}", srcs = [":linker-components-{suffix}", {extra_files_str}])


### PR DESCRIPTION
PR #756 introduced date macro redaction by force-including a generated redacted_dates.h header via the `-imacros` flag in unfiltered compile flags. Since unfiltered compile flags are passed to all driver invocations (including assembly compilations), clang tries to load this header when compiling assembler (`.s` / `.S`) files.

However, redacted_dates.h was only declared as an input file in the C/C++ compiler-components filegroup, and was missing from the assembler-files filegroup. This caused assembly compiles to fail with a fatal error:
  "external/toolchains_llvm++llvm+llvm_toolchain/redacted_dates.h file not found"
as the header was absent from the assembler action's sandbox.

Fix this by adding redacted_dates.h to the assembler-files filegroup definitions (both absolute-path and relative-path configurations) in toolchain/internal/configure.bzl.

Also add a regression test compiling an empty assembly file to ensure the assembler can successfully resolve redacted_dates.h.