### PR TITLE
Fix external tests on Bazel 9.2: patch rules_go duplicate constraints

### DIFF
--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -25,6 +25,16 @@ bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.22")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 bazel_dep(name = "rules_go", version = "0.61.1", repo_name = "io_bazel_rules_go")
+
+# rules_go's `binary_with_rpath` test target lists two values of the same
+# constraint_setting in `target_compatible_with` (os:linux AND os:macos), which
+# Bazel >= 9.2 rejects at analysis time with "Duplicate constraint values
+# detected". Patch it to the canonical OR idiom until it is fixed upstream.
+single_version_override(
+    module_name = "rules_go",
+    patch_strip = 1,
+    patches = ["//:rules_go-fix-binary_with_rpath-constraints.patch"],
+)
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")

--- a/tests/rules_go-fix-binary_with_rpath-constraints.patch
+++ b/tests/rules_go-fix-binary_with_rpath-constraints.patch
@@ -1,0 +1,18 @@
+--- a/tests/core/cgo/BUILD.bazel
++++ b/tests/core/cgo/BUILD.bazel
+@@ -352,10 +352,11 @@
+     out = "binary_with_rpath",
+     cgo = True,
+     gc_linkopts = LARGE_EXT_LDFLAGS,
+-    target_compatible_with = [
+-        "@platforms//os:linux",
+-        "@platforms//os:macos",
+-    ],
++    target_compatible_with = select({
++        "@platforms//os:linux": [],
++        "@platforms//os:macos": [],
++        "//conditions:default": ["@platforms//:incompatible"],
++    }),
+ )
+ 
+ go_binary(

--- a/tests/scripts/run_external_tests.sh
+++ b/tests/scripts/run_external_tests.sh
@@ -93,7 +93,10 @@ if [[ "${_use_bazel_version}" != "8."* ]] && [[ "${USE_BZLMOD:-true}" == "true" 
     generate_imported_dylib_sh="${output_base}/external/io_bazel_rules_go/tests/core/cgo/generate_imported_dylib.sh"
   fi
   echo "Script: '${generate_imported_dylib_sh}'"
-  "${generate_imported_dylib_sh}" "${IMPORTED_C_PATH-}" "${OUTPUT_DIR:-${output_base}}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
+  # The script compiles the `imported.c` next to it into the dylibs expected by
+  # the (manual) dylib_test targets, in the same package directory.
+  _cgo_dir="$(dirname "${generate_imported_dylib_sh}")"
+  "${generate_imported_dylib_sh}" "${IMPORTED_C_PATH:-${_cgo_dir}/imported.c}" "${OUTPUT_DIR:-${_cgo_dir}}" || echo "ERROR: rules_go script 'tests/core/cgo/generate_imported_dylib.sh' failed."
   echo "------------------------------------------------------"
 
   targets+=(


### PR DESCRIPTION
## Summary

All `external_test (…, latest, true, …)` CI jobs have been failing since bazelisk `latest` moved from Bazel 9.1.1 to 9.2.0 (~2026-07-14). This is what is breaking the currently open renovate PRs #804–#808 — in the failing runs 122 of 123 tests pass; the job fails only on an analysis error.

Bazel 9.2 makes duplicate constraint values in `target_compatible_with` a hard analysis-time error. rules_go's `tests/core/cgo:binary_with_rpath` lists both `@platforms//os:linux` and `@platforms//os:macos` (OR was intended, AND was written), so analyzing `@io_bazel_rules_go//tests/core/cgo:all` fails with:

```
ERROR: .../external/rules_go+/tests/core/cgo/BUILD.bazel:346:10: Duplicate constraint values detected:
constraint_setting @@platforms//os:os has [@@platforms//os:linux, @@platforms//os:osx]
```

Under Bazel <= 9.1 the target was silently skipped as incompatible-everywhere, which is why this only surfaced now. The target is still broken on rules_go master, so upgrading rules_go (#807/#808) does not help.

## Changes

- Add `tests/rules_go-fix-binary_with_rpath-constraints.patch`, rewriting the attribute to the canonical OR idiom (`select` with `@platforms//:incompatible` default), applied via `single_version_override` in `tests/MODULE.bazel`. No version pin, so renovate bumps keep working; the patch applies cleanly to rules_go 0.61.1, 0.62.0 and current master. No test is disabled — on the contrary, `binary_with_rpath` now actually builds on linux/macos for the first time.
- Fix the `generate_imported_dylib.sh` invocation in `run_external_tests.sh`: it has always failed with `cc: fatal error: no input files` (masked by `|| echo`) because `IMPORTED_C_PATH` is never set anywhere. Default to the `imported.c` next to the script and output into the cgo package directory. This was never the CI blocker (`dylib_test` is tagged `manual` and never runs), but the ERROR line in every log was a red herring while debugging this.

Follow-up: the proper fix belongs in bazel-contrib/rules_go (`tests/core/cgo/BUILD.bazel`); the local patch can be dropped once a fixed rules_go release is available.

## Test plan

Verified locally on macOS arm64 with Bazel 9.2.0:
- Without the patch: reproduced the exact CI failure (43/44 targets analyzed).
- With the patch: all 44 targets in `@io_bazel_rules_go//tests/core/cgo:all` analyze cleanly, and `binary_with_rpath` builds successfully with the LLVM toolchain.
- The fixed dylib prep invocation generates `libimported.dylib` / `libversioned.*` as intended.