### PR TITLE
chore(deps): combined dependency upgrades unblocked by #810

### DIFF
--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -20,7 +20,7 @@ local_path_override(
     path = "..",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.2")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.22")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -36,7 +36,7 @@ single_version_override(
     patches = ["//:rules_go-fix-binary_with_rpath-constraints.patch"],
 )
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "rules_rust", version = "0.70.0")
+bazel_dep(name = "rules_rust", version = "0.73.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "abseil-cpp", version = "20250814.2", repo_name = "com_google_absl")
 bazel_dep(name = "boringssl", version = "0.20260803.0")

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -39,7 +39,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "abseil-cpp", version = "20250814.2", repo_name = "com_google_absl")
-bazel_dep(name = "boringssl", version = "0.20260526.0")
+bazel_dep(name = "boringssl", version = "0.20260803.0")
 single_version_override(
     module_name = "boringssl",
     patches = ["//:boringssl-20260413.0.patch"],

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -24,7 +24,7 @@ bazel_dep(name = "bazel_skylib", version = "1.9.2")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.22")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-bazel_dep(name = "rules_go", version = "0.61.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.62.0", repo_name = "io_bazel_rules_go")
 
 # rules_go's `binary_with_rpath` test target lists two values of the same
 # constraint_setting in `target_compatible_with` (os:linux AND os:macos), which

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -36,7 +36,7 @@ single_version_override(
     patches = ["//:rules_go-fix-binary_with_rpath-constraints.patch"],
 )
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "rules_rust", version = "0.73.0")
+bazel_dep(name = "rules_rust", version = "0.70.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "abseil-cpp", version = "20250814.2", repo_name = "com_google_absl")
 bazel_dep(name = "boringssl", version = "0.20260803.0")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -415,8 +415,8 @@ protobuf_deps()
 
 http_archive(
     name = "rules_java",
-    sha256 = "9de4e178c2c4f98d32aafe5194c3f2b717ae10405caa11bdcb460ac2a6f61516",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
+    sha256 = "68794ca344c1caf13dca65f90c06660823013fa080931266e2625103904a664e",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.7.0/rules_java-9.7.0.tar.gz"],
 )
 
 load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -345,10 +345,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "763f4a3f6b03469fdb00a77a333dd0b5546d3ee1fa29db373128c08fee73e0e8",
+    sha256 = "0b805c94fb3730dc23df32925ed477b3f4ed37b56075dcac6f218c3ea7b4ab42",
     urls = [
-        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.61.1/rules_go-v0.61.1.zip",
-        "https://github.com/bazel-contrib/rules_go/releases/download/v0.61.1/rules_go-v0.61.1.zip",
+        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.62.0/rules_go-v0.62.0.zip",
+        "https://github.com/bazel-contrib/rules_go/releases/download/v0.62.0/rules_go-v0.62.0.zip",
     ],
 )
 

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -338,9 +338,9 @@ http_archive(
     name = "boringssl",
     patch_args = ["-p1"],
     patches = ["//:boringssl-20260413.0.patch"],
-    sha256 = "6c94f115372978f4505df8280522111c03f2ec4efbdf2dcc713cb8cf1fa9aaab",
-    strip_prefix = "boringssl-0.20260526.0",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260526.0/boringssl-0.20260526.0.tar.gz"],
+    sha256 = "585c91782fc0651ba6f2376b672acdc30437705d8a50b4967c20e6293e318969",
+    strip_prefix = "boringssl-0.20260803.0",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260803.0/boringssl-0.20260803.0.tar.gz"],
 )
 
 http_archive(

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -38,9 +38,9 @@ bazel_features_deps()
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "77f4af7eb3b7573dafa8afab9058ee0d9696209a8b8096ac77646a42d12d0e48",
-    strip_prefix = "bazel-lib-3.5.0",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v3.5.0/bazel-lib-v3.5.0.tar.gz",
+    sha256 = "10f232c10df1ba5cbbbfbcde947090463348f0344d4153e25371b13ee3daf0ce",
+    strip_prefix = "bazel-lib-3.7.1",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v3.7.1/bazel-lib-v3.7.1.tar.gz",
 )
 
 http_archive(

--- a/toolchain/deps.bzl
+++ b/toolchain/deps.bzl
@@ -35,10 +35,10 @@ def bazel_toolchain_dependencies():
         http_archive(
             name = "bazel_skylib",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.9.2/bazel-skylib-1.9.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.2/bazel-skylib-1.9.2.tar.gz",
             ],
-            sha256 = "3b5b49006181f5f8ff626ef8ddceaa95e9bb8ad294f7b5d7b11ea9f7ddaf8c59",
+            sha256 = "37cdfbc6faefea94f7b37760a305c98c08981116c2bc9e821e3b423221fad8c8",
         )
 
     # Load bazel_features if the user has not defined them.


### PR DESCRIPTION
## Summary

Collects all outstanding renovate dependency upgrades, which were previously blocked by the Bazel 9.2 / rules_go analysis error fixed in #810. Each commit is the corresponding renovate PR cherry-picked onto current master:

| PR | Dependency | Version |
|----|------------|---------|
| #804 | rules_java (WORKSPACE) | 9.6.1 → 9.7.0 |
| #805 | aspect_bazel_lib (WORKSPACE) | 3.5.0 → 3.7.1 |
| #806 | bazel_skylib (MODULE + toolchain/deps.bzl) | 1.9.0 → 1.9.2 |
| #776 | boringssl (MODULE + WORKSPACE) | 0.20260526.0 → 0.20260803.0 |
| #787 | rules_rust (MODULE) | ~~0.70.0 → 0.73.0~~ **reverted, stays at 0.70.0** |
| #807 | io_bazel_rules_go (WORKSPACE) | 0.61.1 → 0.62.0 |
| #808 | rules_go (MODULE) | 0.61.1 → 0.62.0 |

Those PRs (except #787) can be closed once this merges (renovate should detect the versions are present).

**Why the rules_rust upgrade was reverted:** rules_rust 0.73.0 no longer ships `rust/repositories.bzl` (WORKSPACE support removed). In the hybrid jobs (Bazel 7/8 with `--enable_bzlmod --enable_workspace`), the root module's `bazel_dep` repos shadow same-named WORKSPACE repos, so the `load("@rules_rust//rust:repositories.bzl", ...)` in `tests/WORKSPACE` resolves to the bzlmod rules_rust and fails to compute the main repository mapping — breaking *every* bazel invocation in those jobs (including msan, which doesn't use rust at all). Bazel 9 jobs are unaffected because WORKSPACE is gone there, and pure-WORKSPACE jobs (bzlmod=false) use the separately pinned rules_rust 0.67.0. Taking 0.73.0 requires first removing the rules_rust block from `tests/WORKSPACE` (nothing in WORKSPACE mode runs rust tests — the rust targets in `run_external_tests.sh` are gated on bzlmod) or dropping the hybrid-mode CI jobs; left for a follow-up.

## Verification (local, macOS arm64, Bazel 9.2.0, bzlmod)

- `@io_bazel_rules_go//tests/core/cgo:all`, `@rules_rust//test/unit/{interleaved_cc_info,native_deps}:all`, `@boringssl//...` and `//foreign:pcre` all analyze cleanly (106 targets) — confirming the #810 rules_go patch applies to 0.62.0 and the boringssl patch applies to 0.20260803.0.
- The test targets excluded in `run_external_tests.sh` all still exist under rules_go 0.62.0, so target-pattern expansion stays valid.

Note: rules_go 0.62.0 has a known Bazel 9 issue with duplicate mingw constraints in its windows cgo platforms (bazel-contrib/rules_go#4665); it should not trigger here since nothing targets Windows, but flagging it in case CI says otherwise.
