### PR TITLE
Update rules_rust to 0.73.0; drop unused rules_rust WORKSPACE setup

### DIFF
--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -36,7 +36,7 @@ single_version_override(
     patches = ["//:rules_go-fix-binary_with_rpath-constraints.patch"],
 )
 bazel_dep(name = "rules_license", version = "1.0.0")
-bazel_dep(name = "rules_rust", version = "0.70.0")
+bazel_dep(name = "rules_rust", version = "0.73.0")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "abseil-cpp", version = "20250814.2", repo_name = "com_google_absl")
 bazel_dep(name = "boringssl", version = "0.20260803.0")

--- a/tests/WORKSPACE
+++ b/tests/WORKSPACE
@@ -367,19 +367,12 @@ maybe(
     name = "host_platform",
 )
 
-# For testing rules_rust.
-
-http_archive(
-    name = "rules_rust",
-    integrity = "sha256-3Ch+PsqAsp1cyV4mHK4nPu3xr0oAqWrpN+I0U02tskw=",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.67.0/rules_rust-0.67.0.tar.gz"],
-)
-
-load("@rules_rust//rust:repositories.bzl", "rules_rust_dependencies", "rust_register_toolchains")
-
-rules_rust_dependencies()
-
-rust_register_toolchains()
+# NOTE: rules_rust is intentionally NOT set up here. The rules_rust tests in
+# run_external_tests.sh only run with bzlmod (see tests/MODULE.bazel). As of
+# rules_rust 0.71 the WORKSPACE support files (rust/repositories.bzl) are gone,
+# and under hybrid mode (--enable_bzlmod --enable_workspace) bazel_dep repos
+# shadow same-named WORKSPACE repos, so loading them here would break the main
+# repository mapping for every hybrid invocation.
 
 http_archive(
     name = "rules_python",


### PR DESCRIPTION
## Summary

Re-applies the rules_rust 0.70.0 → 0.73.0 upgrade (#787) that had to be reverted in #811, by first removing the root cause: the unused rules_rust setup in `tests/WORKSPACE`.

**Why the upgrade broke hybrid mode:** rules_rust ≥ 0.71 no longer ships `rust/repositories.bzl` (WORKSPACE support removed upstream). In the hybrid CI jobs (Bazel 7/8 with `--enable_bzlmod --enable_workspace`), the root module's `bazel_dep` repos shadow same-named WORKSPACE repos — so the `load("@rules_rust//rust:repositories.bzl", ...)` in `tests/WORKSPACE` resolved to the *bzlmod* rules_rust (not the WORKSPACE-pinned 0.67.0 http_archive) and failed with:

```
ERROR: Error computing the main repository mapping: cannot load '@@rules_rust+//rust:repositories.bzl': no such file
```

This killed every bazel invocation in those jobs, including ones that don't use rust at all (msan). Bazel 9 jobs were unaffected (WORKSPACE is gone there); pure-WORKSPACE jobs (bzlmod=false) were unaffected (no shadowing).

**Why removing the WORKSPACE setup is safe:** the rules_rust tests in `run_external_tests.sh` only run with bzlmod enabled (Bazel 9+), and nothing else in the tests workspace uses rust. The WORKSPACE block was dead weight. A comment now documents why it must not be re-added.

Closes #787.

## Test plan

- CI: the hybrid jobs (7.*/8.* with bzlmod=true) are the ones that failed before the revert in #811; they exercise exactly this path.
- Local (macOS arm64): bzlmod analysis of `@rules_rust//test/unit/{interleaved_cc_info,native_deps}:all` at 0.73.0 passed previously on the #811 branch pre-revert; a Bazel 8 hybrid-mode analysis run is in flight and results will be posted here if anything turns up.