### PR TITLE
Expose `clang-apply-replacements` filegroup in the distribution repo

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -242,6 +242,19 @@ sh_test(
     ],
 )
 
+# Verifies the convenience filegroups for the extra LLVM tools are available in
+# the distribution repo, so consumers can depend on e.g.
+# `@llvm_toolchain_llvm//:clang-apply-replacements` the same way they depend on
+# `@llvm_toolchain_llvm//:clang-tidy`.
+build_test(
+    name = "extra_tools_test",
+    targets = [
+        "@llvm_toolchain_llvm//:clang-apply-replacements",
+        "@llvm_toolchain_llvm//:clang-format",
+        "@llvm_toolchain_llvm//:clang-tidy",
+    ],
+)
+
 # As a workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/1018.
 toolchain(
     name = "ninja_mac_arm64_toolchain",

--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -255,6 +255,11 @@ filegroup(
 )
 
 filegroup(
+    name = "clang-apply-replacements",
+    srcs = ["bin/clang-apply-replacements"],
+)
+
+filegroup(
     name = "clang-format",
     srcs = ["bin/clang-format"],
 )


### PR DESCRIPTION
`clang-apply-replacements` shipped in the LLVM distribution and was already an aliased tool (`@llvm_toolchain//:clang-apply-replacements`), but unlike `clang-tidy` and `clang-format` it had no convenience filegroup in the distribution repo. Consumers wiring it up the way they wire `clang-tidy` -- via `@llvm_toolchain_llvm//:clang-tidy` -- hit a "no such target" error.

Add the matching filegroup and a `build_test` covering all three tools.