### PR TITLE
Fix illegal ambiguous match when combining sanitizers (fixes #777)

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -15,7 +15,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
-load(":transitions.bzl", "dwp_file", "msan_flags_test", "sanitizer_test", "stdlib_flags_test", "transition_library_to_platform")
+load(":transitions.bzl", "dwp_file", "msan_flags_test", "sanitizer_combo_flags_test", "sanitizer_test", "stdlib_flags_test", "transition_library_to_platform")
 
 cc_library(
     name = "stdlib",
@@ -92,7 +92,7 @@ cc_test(
 sanitizer_test(
     name = "asan_test",
     src = ":stdlib_bin",
-    sanitizer = "asan",
+    sanitizers = ["asan"],
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )
@@ -100,7 +100,7 @@ sanitizer_test(
 sanitizer_test(
     name = "ubsan_test",
     src = ":stdlib_bin",
-    sanitizer = "ubsan",
+    sanitizers = ["ubsan"],
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )
@@ -108,7 +108,21 @@ sanitizer_test(
 sanitizer_test(
     name = "tsan_test",
     src = ":stdlib_bin",
-    sanitizer = "tsan",
+    sanitizers = ["tsan"],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+# asan and ubsan together: the combination that used to fail analysis with
+# "Illegal ambiguous match" (#777). asan+tsan is not tested because clang
+# rejects that pair outright.
+sanitizer_test(
+    name = "asan_ubsan_test",
+    src = ":stdlib_bin",
+    sanitizers = [
+        "asan",
+        "ubsan",
+    ],
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
 )
@@ -119,6 +133,15 @@ sanitizer_test(
 msan_flags_test(
     name = "msan_flags_test",
     target_compatible_with = ["@platforms//os:linux"],
+    target_under_test = ":stdlib_bin",
+)
+
+# Analysis-only check that two sanitizers can be enabled at once. Not restricted
+# to Linux and not tagged manual: it never links or runs, so it needs no
+# sanitizer runtime, and macOS is where the combination used to fail on the
+# cc_toolchain's dynamic_runtime_lib (#777).
+sanitizer_combo_flags_test(
+    name = "sanitizer_combo_flags_test",
     target_under_test = ":stdlib_bin",
 )
 

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -76,7 +76,7 @@ if [[ -z "${toolchain_name}" ]]; then
     # and listed here only for the default toolchain: they require a sanitizer
     # runtime new enough for the host glibc, which the pinned LLVM 13.0.0
     # toolchain used by the container tests is not.
-    targets+=("//:asan_test" "//:ubsan_test" "//:tsan_test")
+    targets+=("//:asan_test" "//:ubsan_test" "//:tsan_test" "//:asan_ubsan_test")
   fi
 fi
 

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -175,7 +175,7 @@ def _sanitizer_test_impl(ctx):
 # exercising the sanitizer compile/link flags and runtime end to end. Used for
 # asan/ubsan/tsan (msan needs an instrumented libc++). More than one sanitizer
 # covers the combinations that must not produce an ambiguous select() match in
-# the toolchain (see //toolchain/config:use_any_sanitizer).
+# the toolchain (see //toolchain/config:use_asan_ubsan_or_tsan).
 sanitizer_test = rule(
     implementation = _sanitizer_test_impl,
     test = True,

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -148,12 +148,12 @@ transition_binary_to_platform = rule(
 _FEATURES = "//command_line_option:features"
 
 def _sanitizer_transition_impl(settings, attr):
-    # Enable the requested sanitizer via `--features`, matching how sanitizers
+    # Enable the requested sanitizers via `--features`, matching how sanitizers
     # are turned on in normal builds (rules_cc's stock asan/ubsan/tsan
     # features). Using a feature means Bazel resets it to `--host_features` in
     # the exec configuration, so build tools stay uninstrumented.
-    features = [f for f in settings[_FEATURES] if f != attr.sanitizer]
-    return {_FEATURES: features + [attr.sanitizer]}
+    features = [f for f in settings[_FEATURES] if f not in attr.sanitizers]
+    return {_FEATURES: features + attr.sanitizers}
 
 _sanitizer_transition = transition(
     implementation = _sanitizer_transition_impl,
@@ -171,15 +171,20 @@ def _sanitizer_test_impl(ctx):
         runfiles = ctx.attr.src[0][DefaultInfo].default_runfiles,
     )]
 
-# Builds and runs `src` with a single sanitizer enabled via `--features`,
+# Builds and runs `src` with the given sanitizers enabled via `--features`,
 # exercising the sanitizer compile/link flags and runtime end to end. Used for
-# asan/ubsan/tsan (msan needs an instrumented libc++).
+# asan/ubsan/tsan (msan needs an instrumented libc++). More than one sanitizer
+# covers the combinations that must not produce an ambiguous select() match in
+# the toolchain (see //toolchain/config:use_any_sanitizer).
 sanitizer_test = rule(
     implementation = _sanitizer_test_impl,
     test = True,
     attrs = {
         "src": attr.label(mandatory = True, cfg = _sanitizer_transition),
-        "sanitizer": attr.string(mandatory = True, values = ["asan", "ubsan", "tsan"]),
+        "sanitizers": attr.string_list(
+            mandatory = True,
+            allow_empty = False,
+        ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
@@ -216,6 +221,37 @@ msan_flags_test = analysistest.make(
     _msan_flags_test_impl,
     config_settings = {
         "//command_line_option:features": ["msan"],
+    },
+)
+
+def _sanitizer_combo_flags_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    cpp_actions = [
+        a
+        for a in analysistest.target_actions(env)
+        if a.mnemonic == "CppCompile"
+    ]
+    asserts.true(env, len(cpp_actions) > 0, "expected a CppCompile action")
+    argv = cpp_actions[0].argv
+    for flag in ["-fsanitize=address", "-fsanitize=undefined"]:
+        asserts.true(
+            env,
+            flag in argv,
+            "expected %s on the compile command line, got: %s" % (flag, argv),
+        )
+    return analysistest.end(env)
+
+# Analysis-only test for combined sanitizers. Its real job is to reach analysis
+# at all: the use_asan/use_ubsan/use_tsan config_settings match `--features`, so
+# they are not mutually exclusive, and a select() keying on more than one of
+# them fails with "Illegal ambiguous match" as soon as two sanitizers are
+# enabled together (#777). Because it only analyses, it runs on every platform,
+# including macOS -- where the ambiguity hits the cc_toolchain's
+# dynamic_runtime_lib rather than the toolchain config's link flags.
+sanitizer_combo_flags_test = analysistest.make(
+    _sanitizer_combo_flags_test_impl,
+    config_settings = {
+        "//command_line_option:features": ["asan", "ubsan"],
     },
 )
 

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -175,7 +175,7 @@ def _sanitizer_test_impl(ctx):
 # exercising the sanitizer compile/link flags and runtime end to end. Used for
 # asan/ubsan/tsan (msan needs an instrumented libc++). More than one sanitizer
 # covers the combinations that must not produce an ambiguous select() match in
-# the toolchain (see //toolchain/config:use_asan_ubsan_or_tsan).
+# the toolchain (see //toolchain/config:use_common_sanitizer).
 sanitizer_test = rule(
     implementation = _sanitizer_test_impl,
     test = True,

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -859,6 +859,13 @@ def cc_toolchain_config(
     # than a //toolchain/config flag) means the augmentation is reset to
     # `--host_features` in the exec configuration, so build tools stay
     # uninstrumented -- matching how the stock features themselves behave.
+    #
+    # Sanitizers combine (`--features=asan --features=ubsan` is a supported
+    # build), and the use_* settings all match at once when they do. A single
+    # select() keyed on several of them is then an ambiguous match and Bazel
+    # fails analysis, so the flags are assembled from selects that each key on
+    # exactly one condition: what all sanitizers share keys on
+    # use_any_sanitizer, what only ubsan needs keys on use_ubsan.
     sanitizer_compile_flags = select({
         str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
             "-fsanitize=bounds",
@@ -867,16 +874,14 @@ def cc_toolchain_config(
         "//conditions:default": [],
     })
     sanitizer_link_flags = select({
-        str(Label("@toolchains_llvm//toolchain/config:use_asan")): [
+        str(Label("@toolchains_llvm//toolchain/config:use_any_sanitizer")): [
             "-fsanitize-link-c++-runtime",
         ],
+        "//conditions:default": [],
+    }) + select({
         str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
-            "-fsanitize-link-c++-runtime",
             "-fsanitize=bounds",
             "-fsanitize=nullability",
-        ],
-        str(Label("@toolchains_llvm//toolchain/config:use_tsan")): [
-            "-fsanitize-link-c++-runtime",
         ],
         "//conditions:default": [],
     })
@@ -902,9 +907,7 @@ def cc_toolchain_config(
         )
         runfiles_feature_label = ":" + name + "_sanitizer_runtime_runfiles"
         sanitizer_runtime_features = select({
-            str(Label("@toolchains_llvm//toolchain/config:use_asan")): [runfiles_feature_label],
-            str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [runfiles_feature_label],
-            str(Label("@toolchains_llvm//toolchain/config:use_tsan")): [runfiles_feature_label],
+            str(Label("@toolchains_llvm//toolchain/config:use_any_sanitizer")): [runfiles_feature_label],
             "//conditions:default": [],
         })
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -864,8 +864,11 @@ def cc_toolchain_config(
     # build), and the use_* settings all match at once when they do. A single
     # select() keyed on several of them is then an ambiguous match and Bazel
     # fails analysis, so the flags are assembled from selects that each key on
-    # exactly one condition: what all sanitizers share keys on
-    # use_any_sanitizer, what only ubsan needs keys on use_ubsan.
+    # exactly one condition: what asan/ubsan/tsan share keys on
+    # use_asan_ubsan_or_tsan, what only ubsan needs keys on use_ubsan. msan is
+    # not involved -- it is carried by the msan/nomsan cc_features below, not by
+    # a select() -- and rules_cc's stock `lsan` feature is not augmented here at
+    # all; see //toolchain/config for both.
     sanitizer_compile_flags = select({
         str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
             "-fsanitize=bounds",
@@ -874,7 +877,7 @@ def cc_toolchain_config(
         "//conditions:default": [],
     })
     sanitizer_link_flags = select({
-        str(Label("@toolchains_llvm//toolchain/config:use_any_sanitizer")): [
+        str(Label("@toolchains_llvm//toolchain/config:use_asan_ubsan_or_tsan")): [
             "-fsanitize-link-c++-runtime",
         ],
         "//conditions:default": [],
@@ -907,7 +910,7 @@ def cc_toolchain_config(
         )
         runfiles_feature_label = ":" + name + "_sanitizer_runtime_runfiles"
         sanitizer_runtime_features = select({
-            str(Label("@toolchains_llvm//toolchain/config:use_any_sanitizer")): [runfiles_feature_label],
+            str(Label("@toolchains_llvm//toolchain/config:use_asan_ubsan_or_tsan")): [runfiles_feature_label],
             "//conditions:default": [],
         })
 

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -865,10 +865,10 @@ def cc_toolchain_config(
     # select() keyed on several of them is then an ambiguous match and Bazel
     # fails analysis, so the flags are assembled from selects that each key on
     # exactly one condition: what asan/ubsan/tsan share keys on
-    # use_asan_ubsan_or_tsan, what only ubsan needs keys on use_ubsan. msan is
+    # use_common_sanitizer, what only ubsan needs keys on use_ubsan. msan is
     # not involved -- it is carried by the msan/nomsan cc_features below, not by
-    # a select() -- and rules_cc's stock `lsan` feature is not augmented here at
-    # all; see //toolchain/config for both.
+    # a select() -- and rules_cc's stock `lsan` feature is not augmented here
+    # yet; see //toolchain/config for both.
     sanitizer_compile_flags = select({
         str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
             "-fsanitize=bounds",
@@ -877,7 +877,7 @@ def cc_toolchain_config(
         "//conditions:default": [],
     })
     sanitizer_link_flags = select({
-        str(Label("@toolchains_llvm//toolchain/config:use_asan_ubsan_or_tsan")): [
+        str(Label("@toolchains_llvm//toolchain/config:use_common_sanitizer")): [
             "-fsanitize-link-c++-runtime",
         ],
         "//conditions:default": [],
@@ -910,7 +910,7 @@ def cc_toolchain_config(
         )
         runfiles_feature_label = ":" + name + "_sanitizer_runtime_runfiles"
         sanitizer_runtime_features = select({
-            str(Label("@toolchains_llvm//toolchain/config:use_asan_ubsan_or_tsan")): [runfiles_feature_label],
+            str(Label("@toolchains_llvm//toolchain/config:use_common_sanitizer")): [runfiles_feature_label],
             "//conditions:default": [],
         })
 

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -83,8 +83,8 @@ config_setting(
 # anything shared by asan/ubsan/tsan keys on this group instead, and anything
 # sanitizer-specific gets its own single-condition select().
 #
-# The group is named after its exact members rather than "any sanitizer",
-# because it is not all of them and the set is expected to change:
+# The group holds the sanitizers that need the same treatment, not every
+# sanitizer, and it is expected to grow:
 #
 #   msan needs no config_setting of its own. It is driven entirely by the
 #   mutually-exclusive msan/nomsan cc_features in cc_toolchain_config.bzl, so
@@ -93,16 +93,19 @@ config_setting(
 #   itself rather than through `-fsanitize-link-c++-runtime`, and it is
 #   Linux-only, so the macOS runtime dylibs never apply.
 #
-#   lsan is a stock rules_cc sanitizer feature (`--features=lsan`,
-#   -fsanitize=leak) that this toolchain does not augment at all -- there is no
-#   :use_lsan setting above. Standalone LSan has no separate C++ runtime to
-#   link and clang does not support it on Apple targets, so it likely needs
-#   nothing here, but that has not been verified. Adding a setting for it means
-#   revisiting this group.
+#   lsan belongs here but is not wired up yet. rules_cc ships four stock
+#   sanitizer features -- asan, lsan, tsan, ubsan -- and there is no :use_lsan
+#   setting above, so `--features=lsan` gets no augmentation. On macOS the
+#   linked binary does reference @rpath/libclang_rt.lsan_osx_dynamic.dylib,
+#   which nothing then ships into runfiles: the same failure #769 fixed for the
+#   other three. Adding it is a behaviour change for lsan builds and wants its
+#   own test, so it is deliberately left to a follow-up.
 #
-# Anything added here must keep every select() keyed on exactly one condition.
+# Newer sanitizers keep appearing (the LLVM distributions already carry an
+# rtsan runtime), so expect to extend this. Anything added here must keep every
+# select() keyed on exactly one condition.
 selects.config_setting_group(
-    name = "use_asan_ubsan_or_tsan",
+    name = "use_common_sanitizer",
     match_any = [
         ":use_asan",
         ":use_ubsan",

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 bool_flag(
@@ -73,5 +74,20 @@ config_setting(
 config_setting(
     name = "use_tsan",
     values = {"features": "tsan"},
+    visibility = ["//visibility:public"],
+)
+
+# The three settings above are not mutually exclusive: `--features=asan
+# --features=ubsan` matches both. A select() may therefore only key on more
+# than one of them when every matching branch resolves to the same value, so
+# anything shared by all sanitizers keys on this group instead, and anything
+# sanitizer-specific gets its own single-condition select().
+selects.config_setting_group(
+    name = "use_any_sanitizer",
+    match_any = [
+        ":use_asan",
+        ":use_ubsan",
+        ":use_tsan",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -80,10 +80,29 @@ config_setting(
 # The three settings above are not mutually exclusive: `--features=asan
 # --features=ubsan` matches both. A select() may therefore only key on more
 # than one of them when every matching branch resolves to the same value, so
-# anything shared by all sanitizers keys on this group instead, and anything
+# anything shared by asan/ubsan/tsan keys on this group instead, and anything
 # sanitizer-specific gets its own single-condition select().
+#
+# The group is named after its exact members rather than "any sanitizer",
+# because it is not all of them and the set is expected to change:
+#
+#   msan needs no config_setting of its own. It is driven entirely by the
+#   mutually-exclusive msan/nomsan cc_features in cc_toolchain_config.bzl, so
+#   no select() keys on it and it cannot produce an ambiguous match. It also
+#   does not want what this group guards: it links the instrumented libc++
+#   itself rather than through `-fsanitize-link-c++-runtime`, and it is
+#   Linux-only, so the macOS runtime dylibs never apply.
+#
+#   lsan is a stock rules_cc sanitizer feature (`--features=lsan`,
+#   -fsanitize=leak) that this toolchain does not augment at all -- there is no
+#   :use_lsan setting above. Standalone LSan has no separate C++ runtime to
+#   link and clang does not support it on Apple targets, so it likely needs
+#   nothing here, but that has not been verified. Adding a setting for it means
+#   revisiting this group.
+#
+# Anything added here must keep every select() keyed on exactly one condition.
 selects.config_setting_group(
-    name = "use_any_sanitizer",
+    name = "use_asan_ubsan_or_tsan",
     match_any = [
         ":use_asan",
         ":use_ubsan",

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -766,7 +766,7 @@ system_module_map(
 )
 
 filegroup(name = "runtime-libs-empty-{suffix}", srcs = [])
-
+{sanitizer_runtime_filegroup}
 cc_toolchain(
     name = "cc-clang-{suffix}",
     all_files = "all-files-{suffix}",
@@ -805,15 +805,38 @@ cc_toolchain(
     # a format argument (not inlined in the template) so its select() braces
     # are not re-interpreted by the outer format().
     runtime_lib_attrs = ""
+    runtime_lib_filegroup = ""
     if target_os == "darwin" and not use_absolute_paths_llvm:
         runtime_lib_attrs = """
     static_runtime_lib = ":runtime-libs-empty-{suffix}",
-    dynamic_runtime_lib = select({{
-        "{use_asan}": "{root}:libclang_rt-asan-darwin",
-        "{use_ubsan}": "{root}:libclang_rt-ubsan-darwin",
-        "{use_tsan}": "{root}:libclang_rt-tsan-darwin",
-        "//conditions:default": ":runtime-libs-empty-{suffix}",
-    }}),""".format(
+    dynamic_runtime_lib = ":sanitizer-runtime-libs-{suffix}",""".format(suffix = suffix)
+
+        # Like runtime_lib_attrs, this is passed as a format argument rather
+        # than inlined into the template, so its select() braces are not
+        # re-interpreted by the outer format().
+        #
+        # Sanitizers combine, so the enabled ones cannot be picked with a single
+        # select() over the use_* settings: they all match at once and Bazel
+        # rejects the ambiguous match. dynamic_runtime_lib takes one label, so
+        # instead of selecting the label, select the filegroup's contents -- one
+        # single-condition select() per sanitizer, concatenated. A combined
+        # build then gets exactly the runtimes it enabled, and no combination is
+        # ambiguous.
+        runtime_lib_filegroup = """
+filegroup(
+    name = "sanitizer-runtime-libs-{suffix}",
+    srcs = select({{
+        "{use_asan}": ["{root}:libclang_rt-asan-darwin"],
+        "//conditions:default": [],
+    }}) + select({{
+        "{use_ubsan}": ["{root}:libclang_rt-ubsan-darwin"],
+        "//conditions:default": [],
+    }}) + select({{
+        "{use_tsan}": ["{root}:libclang_rt-tsan-darwin"],
+        "//conditions:default": [],
+    }}),
+)
+""".format(
             suffix = suffix,
             root = target_toolchain_root,
             use_asan = str(Label("//toolchain/config:use_asan")),
@@ -883,6 +906,7 @@ cc_toolchain(
         extra_exec_compatible_with_all_targets = toolchain_info.extra_exec_compatible_with.get("", []),
         extra_target_compatible_with_all_targets = toolchain_info.extra_target_compatible_with.get("", []),
         runtime_lib_attrs = runtime_lib_attrs,
+        sanitizer_runtime_filegroup = runtime_lib_filegroup,
     )
 
 def _is_remote(rctx, exec_os, exec_arch):


### PR DESCRIPTION
Fixes #777.

## Problem

Enabling two sanitizers at once fails during analysis:

```
$ bazel build //:stdlib_test --features=asan --features=ubsan
ERROR: .../llvm_toolchain/BUILD.bazel:194:13: Illegal ambiguous match on
configurable attribute "dynamic_runtime_lib" in
@@toolchains_llvm++llvm+llvm_toolchain//:cc-clang-aarch64-darwin:
@@toolchains_llvm+//toolchain/config:use_asan
@@toolchains_llvm+//toolchain/config:use_ubsan
```

`//toolchain/config:use_asan`, `:use_ubsan` and `:use_tsan` match on
`values = {"features": ...}`, so they are **not** mutually exclusive. With two
sanitizers on, two branches of the same `select()` match, and Bazel rejects an
ambiguous match unless one condition is more specialized or all matches resolve
to the same value.

The regression came in with the v1.8.0 sanitizer work (#765, #769) and is live
in the v1.8.0 that BCR serves. It shows up on `link_flags` on Linux (as in the
issue report) and on `dynamic_runtime_lib` on macOS. CI missed it because every
sanitizer test enables exactly one sanitizer.

## Fix

Make every sanitizer `select()` key on exactly one condition.

- New `//toolchain/config:use_any_sanitizer` (`config_setting_group`,
  `match_any`) for what all sanitizers share: the `-fsanitize-link-c++-runtime`
  link flag and the darwin runfiles feature. ubsan's extra
  `-fsanitize=bounds` / `-fsanitize=nullability` keep their own `:use_ubsan`
  select and are concatenated.
- `dynamic_runtime_lib` takes a single label, so it can't be built by
  concatenation. It now points unconditionally at a
  `sanitizer-runtime-libs-{suffix}` filegroup whose `srcs` are the
  concatenation of one single-condition `select()` per sanitizer, so a combined
  build gets exactly the runtime dylibs it enabled:

  ```python
  filegroup(
      name = "sanitizer-runtime-libs-aarch64-darwin",
      srcs = select({"...:use_asan": ["...:libclang_rt-asan-darwin"], "//conditions:default": []}) +
             select({"...:use_ubsan": ["...:libclang_rt-ubsan-darwin"], "//conditions:default": []}) +
             select({"...:use_tsan": ["...:libclang_rt-tsan-darwin"], "//conditions:default": []}),
  )
  ```

The darwin runfiles-feature select previously listed all three conditions with
identical values, which was legal only under the "resolve to the same value"
rule. Keying it on the group removes that subtlety.

## Tests

- `sanitizer_test`'s `sanitizer` string attr becomes a `sanitizers` list; new
  `//:asan_ubsan_test` builds and runs the combination end to end on Linux, and
  is listed in `tests/scripts/run_tests.sh` next to the existing sanitizer
  tests. asan+tsan is not covered because clang rejects that pair outright.
- New analysis-only `//:sanitizer_combo_flags_test` enables asan and ubsan
  together. Analysis-only means no sanitizer runtime is needed, so it also runs
  on macOS -- the only platform where the `dynamic_runtime_lib` ambiguity
  appears.

Verified locally on macOS (aarch64): `bazel build //:stdlib_test
--features=asan --features=ubsan` fails on master with the error above and
succeeds with this change; `//:sanitizer_combo_flags_test` fails with that same
error when the toolchain changes are reverted and passes with them.

This is one of the two regressions blocking the next release.

## What about the other sanitizers?

Worth stating explicitly, since "which sanitizers does this cover" is the
obvious question:

| Sanitizer | Driven by | Affected by #777? | Covered by the group? |
| --- | --- | --- | --- |
| asan | `:use_asan` config_setting | yes | yes |
| ubsan | `:use_ubsan` config_setting | yes | yes |
| tsan | `:use_tsan` config_setting | yes | yes |
| msan | `msan`/`nomsan` cc_features | no | no, by design |
| lsan | rules_cc stock feature, not augmented here | no | no -- gap, see below |

**msan** cannot hit this bug: it is carried entirely by the mutually-exclusive
`msan`/`nomsan` cc_features in `cc_toolchain_config.bzl`, so no `select()` keys
on it and there is no `:use_msan` setting to be ambiguous with anything. It
also does not want what the group guards -- it links the instrumented libc++
itself (`-l:libc++.a`, `-rtlib=compiler-rt`) rather than through
`-fsanitize-link-c++-runtime`, and it is Linux-only, so the macOS runtime
dylibs never apply. `--features=msan --features=ubsan` works after this change
for the same reason it is unaffected before it.

**lsan** is the one worth flagging, and it turned out to be a real bug rather
than a naming nit. rules_cc ships four stock sanitizer features -- asan,
**lsan**, tsan, ubsan -- and this toolchain only has config_settings for three,
so `--features=lsan` gets no augmentation. On macOS that is not cosmetic: an
lsan binary links against `@rpath/libclang_rt.lsan_osx_dynamic.dylib`
(confirmed with `otool -L`), and with no `:use_lsan` setting nothing ships that
dylib into runfiles -- the same failure #769 fixed for the other three.

Wiring lsan up changes behaviour for lsan builds and wants its own test, so I
have deliberately left it out of this PR rather than widen a release-blocking
regression fix, and recorded it where the group is defined. Happy to open the
follow-up.

The group is therefore named `use_common_sanitizer` -- for the treatment it
applies, not its current membership, since lsan should join it and the LLVM
distributions already carry an `rtsan` runtime besides. Both the msan exclusion
and the lsan gap are documented at the definition.
