### PR TITLE
Revert "Redact date macros via -imacros header instead of -D on command line (#756)"

### DIFF
--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -67,7 +67,6 @@ def cc_toolchain_config(
         target_toolchain_path_prefix,
         tools_path_prefix,
         wrapper_bin_prefix,
-        redacted_dates_path,
         compiler_configuration,
         cxx_builtin_include_directories,
         extra_known_features,
@@ -224,12 +223,11 @@ def cc_toolchain_config(
     unfiltered_compile_flags = [
         # Do not resolve our symlinked resource prefixes to real paths.
         "-no-canonical-prefixes",
-        # Reproducibility: redact date macros via an -imacros header rather than
-        # -D__DATE__="redacted" on the command line, whose quotes are lost when
-        # passed through sub-build flag strings.
+        # Reproducibility
         "-Wno-builtin-macro-redefined",
-        "-imacros",
-        redacted_dates_path,
+        "-D__DATE__=\"redacted\"",
+        "-D__TIMESTAMP__=\"redacted\"",
+        "-D__TIME__=\"redacted\"",
     ]
 
     major_llvm_version = int(llvm_version.split(".")[0])

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -361,13 +361,6 @@ def llvm_config_impl(rctx):
         },
     )
 
-    rctx.file(
-        "redacted_dates.h",
-        "#define __DATE__      \"redacted\"\n" +
-        "#define __TIME__      \"redacted\"\n" +
-        "#define __TIMESTAMP__ \"redacted\"\n",
-    )
-
     if hasattr(rctx, "repo_metadata"):
         return rctx.repo_metadata(reproducible = True)
     else:
@@ -600,7 +593,6 @@ cc_toolchain_config(
     target_toolchain_path_prefix = "{target_toolchain_path_prefix}",
     tools_path_prefix = "{tools_path_prefix}",
     wrapper_bin_prefix = "{wrapper_bin_prefix}",
-    redacted_dates_path = "{redacted_dates_path}",
     compiler_configuration = {{
       "sysroot_path": "{sysroot_path}",
       "stdlib": "{stdlib}",
@@ -672,7 +664,6 @@ filegroup(
     name = "compiler-components-{suffix}",
     srcs = [
         ":sysroot-components-{suffix}",
-        "redacted_dates.h",
         {extra_compiler_files}
     ],
 )
@@ -695,7 +686,7 @@ filegroup(
 
 filegroup(name = "all-files-{suffix}", srcs = [":all-components-{suffix}", {extra_files_str}])
 filegroup(name = "archiver-files-{suffix}", srcs = [{extra_files_str}])
-filegroup(name = "assembler-files-{suffix}", srcs = ["redacted_dates.h", {extra_files_str}])
+filegroup(name = "assembler-files-{suffix}", srcs = [{extra_files_str}])
 filegroup(name = "compiler-files-{suffix}", srcs = [":compiler-components-{suffix}", {extra_files_str}])
 filegroup(name = "dwp-files-{suffix}", srcs = [{extra_files_str}])
 filegroup(name = "linker-files-{suffix}", srcs = [":linker-components-{suffix}", {extra_files_str}])
@@ -719,7 +710,6 @@ filegroup(
         ":sysroot-components-{suffix}",
         "{llvm_dist_label_prefix}extra_config_site",
         "{toolchain_root}:clang",
-        "redacted_dates.h",
         {extra_compiler_files}
     ],
 )
@@ -747,7 +737,7 @@ filegroup(
 
 filegroup(name = "all-files-{suffix}", srcs = [":all-components-{suffix}", {extra_files_str}])
 filegroup(name = "archiver-files-{suffix}", srcs = ["{llvm_dist_label_prefix}ar", {extra_files_str}])
-filegroup(name = "assembler-files-{suffix}", srcs = ["{llvm_dist_label_prefix}as", "redacted_dates.h", {extra_files_str}])
+filegroup(name = "assembler-files-{suffix}", srcs = ["{llvm_dist_label_prefix}as", {extra_files_str}])
 filegroup(name = "compiler-files-{suffix}", srcs = [":compiler-components-{suffix}", {extra_files_str}])
 filegroup(name = "dwp-files-{suffix}", srcs = ["{llvm_dist_label_prefix}dwp", {extra_files_str}])
 filegroup(name = "linker-files-{suffix}", srcs = [":linker-components-{suffix}", {extra_files_str}])
@@ -760,7 +750,6 @@ system_module_map(
     name = "module-{suffix}",
     cxx_builtin_include_files = ":cxx_builtin_include_files-{suffix}",
     cxx_builtin_include_directories = {cxx_builtin_include_directories},
-    extra_textual_headers = "redacted_dates.h",
     sysroot_files = ":sysroot-components-{suffix}",
     sysroot_path = "{sysroot_path}",
 )
@@ -838,7 +827,6 @@ cc_toolchain(
         target_toolchain_path_prefix = target_toolchain_path_prefix,
         tools_path_prefix = toolchain_info.tools_path_prefix,
         wrapper_bin_prefix = toolchain_info.wrapper_bin_prefix,
-        redacted_dates_path = "external/{}/redacted_dates.h".format(rctx.name),
         sysroot_label_str = sysroot_label_str,
         sysroot_path = sysroot_path,
         stdlib = stdlib,

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -60,25 +60,7 @@ def _system_module_map(ctx):
         paths.join(execroot_prefix, file.path),
     )
 
-    # Unlike cxx_builtin_include_files, whose entries are source directories
-    # emitted as umbrella submodules, these are individual headers (e.g. a
-    # force-included header) that must always be emitted as textual headers.
-    forced_textual_header_closure = lambda file: "  textual header \"{}\"".format(
-        paths.join(execroot_prefix, file.path),
-    )
-
     template_dict = ctx.actions.template_dict()
-
-    if ctx.attr.extra_textual_headers:
-        template_dict.add_joined(
-            "%extra_textual_headers%",
-            ctx.attr.extra_textual_headers[DefaultInfo].files,
-            join_with = "\n",
-            map_each = forced_textual_header_closure,
-            allow_closure = True,
-        )
-    else:
-        template_dict.add("%extra_textual_headers%", "")
 
     if bazel_features.rules.merkle_cache_v2:
         # If provided, cxx_builtin_files should be a filegroup with 2 source directory entries:
@@ -139,7 +121,6 @@ system_module_map = rule(
     attrs = {
         "cxx_builtin_include_files": attr.label(mandatory = True),
         "cxx_builtin_include_directories": attr.string_list(mandatory = True),
-        "extra_textual_headers": attr.label(allow_files = True),
         "sysroot_files": attr.label(),
         "sysroot_path": attr.string(),
         "_module_map_template": attr.label(

--- a/toolchain/internal/template.modulemap
+++ b/toolchain/internal/template.modulemap
@@ -1,6 +1,5 @@
 module "crosstool" [system] {
 %cxx_builtin_include_files%
-%extra_textual_headers%
 %sysroot%
 %umbrella_submodules%
 }


### PR DESCRIPTION
Fixes #771. Reverts #756.

This is the second of the two regressions blocking the next release; #824 is
the other.

## Why

#756 replaced `-D__DATE__="redacted"` (and `__TIME__`/`__TIMESTAMP__`) in
`unfiltered_compile_flags` with a generated `redacted_dates.h` force-included
via `-imacros`. The motivation was real: the quotes are required, but they do
not survive being passed through sub-build flag strings, so consumers that
re-serialize the toolchain's compile flags into their own build scripts
(rules_foreign_cc make/cmake, embedded compiler-flag strings) end up with a
bare `redacted` token that clang rejects.

Force-including a file from the toolchain turned out to cost more than the
quoting problem it solved:

- It broke rules_rust `cargo_build_script` under
  `--strategy=CargoBuildScriptRun=local` (#771).
- It broke assembly compilation: unfiltered flags reach every driver
  invocation, but the header was only an input to the C/C++ compiler filegroup
  (#801).
- Being a real file, it has to be threaded through the system module map for
  `layering_check` and through every filegroup feeding a compile action. Each
  new action type is another place to forget it.

Both proposed opt-outs were rejected -- an env-var toggle (#772) and a feature
toggle (#774, "we decided against this feature"). Without an opt-out there is
no way to unbreak the affected consumers, and v1.8.0 -- which is what BCR
serves today -- carries the breakage. @fmeum raised rolling this back in
https://github.com/bazel-contrib/toolchains_llvm/pull/801#issuecomment-4939040588.

## What this does

- Reverts 1194923 in full.
- Drops `redacted_dates.h` from the `assembler-files-*` filegroups added by
  #801, since the header is no longer generated.
- Keeps #801's `tests/assembly_test.s` and `//:assembly_test`. @AustinSchuh
  confirmed the test catches the original breakage and asked for it to land
  regardless; it now guards a path that no longer has the bug, which is where
  you want a test.

The only conflict was in `toolchain/internal/system_module_map.bzl`, where #761
had rewritten the surrounding lines to use `paths.join`; there is no semantic
overlap, so the #756 block was simply removed. `extra_textual_headers` was an
attribute of the internal `system_module_map` rule only, so nothing public
changes.

## Trade-off

This reintroduces the original limitation: consumers that re-serialize the
toolchain's compile flags into a sub-build command line lose the quotes around
`redacted`. That failure mode requires opting into re-serializing toolchain
flags, whereas the `-imacros` failure mode hit ordinary builds. Per the
discussion on #771 the general problem (toolchain flags losing quoting when
re-serialized) is better addressed in the consumer; I will file that against
rules_rust.

Kept as a single clean revert commit, so re-reverting is trivial if someone
lands a better fix for the quoting problem.

## Verification

Built on macOS (aarch64) with the reverted toolchain: `//:assembly_test_lib`
(the target #801 added), `//:stdlib_test`, `//:test_cxx_standard_is_17`. No
references to `redacted_dates`, `-imacros` or `extra_textual_headers` remain.
