### PR TITLE
Wire up LeakSanitizer support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,24 @@ jobs:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
           USE_BZLMOD: ${{ matrix.bzlmod }}
         run: tests/scripts/run_tests.sh -O
+  lsan_macos_test:
+    # LLVM <= 21 deadlocks while enumerating dyld images during LSan's exit
+    # check on current macOS. LLVM 22 uses _dyld_get_dyld_header instead; keep a
+    # focused test pinned to the first release line containing that fix.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test LSan with LLVM 22
+        env:
+          USE_BAZEL_VERSION: latest
+          USE_BZLMOD: true
+        run: |
+          source tests/scripts/bazel.sh
+          cd tests
+          "${bazel}" --bazelrc=/dev/null test \
+            "${common_test_args[@]}" \
+            --repo_env=LLVM_VERSION=22.1.8 \
+            //:lsan_test
   toolchain_test:
     strategy:
       fail-fast: false
@@ -195,6 +213,7 @@ jobs:
     needs:
       - lint
       - test
+      - lsan_macos_test
       - toolchain_test
       - external_test
       - container_test

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -77,11 +77,11 @@ cc_test(
     deps = [":stdlib"],
 )
 
-# Sanitizer support (rules_cc's stock asan/ubsan/tsan features, augmented by the
-# toolchain with the C++ sanitizer runtime). The transition enables a single
-# sanitizer via `--features` for the wrapped binary so the test runs regardless
-# of the global build flags. Restricted to Linux, where the toolchain ships the
-# sanitizer runtimes.
+# Sanitizer support (rules_cc's stock asan/lsan/ubsan/tsan features, augmented
+# by the toolchain with the C++ sanitizer runtime). The transition enables a
+# single sanitizer via `--features` for the wrapped binary so the test runs
+# regardless of the global build flags. The tests are restricted to Linux
+# except for lsan, whose macOS runtime is usable with LLVM 22 or newer.
 #
 # Tagged `manual` so the default `bazel test //...`/`//:all` does not pick them
 # up: the `container_test` job runs `//:all` against the pinned LLVM 13.0.0
@@ -103,6 +103,13 @@ sanitizer_test(
     sanitizers = ["ubsan"],
     tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
+)
+
+sanitizer_test(
+    name = "lsan_test",
+    src = ":stdlib_bin",
+    sanitizers = ["lsan"],
+    tags = ["manual"],
 )
 
 sanitizer_test(

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -76,7 +76,7 @@ if [[ -z "${toolchain_name}" ]]; then
     # and listed here only for the default toolchain: they require a sanitizer
     # runtime new enough for the host glibc, which the pinned LLVM 13.0.0
     # toolchain used by the container tests is not.
-    targets+=("//:asan_test" "//:ubsan_test" "//:tsan_test" "//:asan_ubsan_test")
+    targets+=("//:asan_test" "//:lsan_test" "//:ubsan_test" "//:tsan_test" "//:asan_ubsan_test")
   fi
 fi
 

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -149,7 +149,7 @@ _FEATURES = "//command_line_option:features"
 
 def _sanitizer_transition_impl(settings, attr):
     # Enable the requested sanitizers via `--features`, matching how sanitizers
-    # are turned on in normal builds (rules_cc's stock asan/ubsan/tsan
+    # are turned on in normal builds (rules_cc's stock asan/lsan/ubsan/tsan
     # features). Using a feature means Bazel resets it to `--host_features` in
     # the exec configuration, so build tools stay uninstrumented.
     features = [f for f in settings[_FEATURES] if f not in attr.sanitizers]
@@ -173,7 +173,7 @@ def _sanitizer_test_impl(ctx):
 
 # Builds and runs `src` with the given sanitizers enabled via `--features`,
 # exercising the sanitizer compile/link flags and runtime end to end. Used for
-# asan/ubsan/tsan (msan needs an instrumented libc++). More than one sanitizer
+# asan/lsan/ubsan/tsan (msan needs an instrumented libc++). More than one sanitizer
 # covers the combinations that must not produce an ambiguous select() match in
 # the toolchain (see //toolchain/config:use_common_sanitizer).
 sanitizer_test = rule(

--- a/toolchain/BUILD.llvm_repo.tpl
+++ b/toolchain/BUILD.llvm_repo.tpl
@@ -184,6 +184,14 @@ filegroup(
 )
 
 filegroup(
+    name = "libclang_rt-lsan-darwin",
+    srcs = glob(
+        ["lib/clang/{LLVM_VERSION}/lib/darwin/libclang_rt.lsan_osx_dynamic.dylib"],
+        allow_empty = True,
+    ),
+)
+
+filegroup(
     name = "libclang_rt-tsan-darwin",
     srcs = glob(
         ["lib/clang/{LLVM_VERSION}/lib/darwin/libclang_rt.tsan_osx_dynamic.dylib"],

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -318,16 +318,16 @@ def cc_toolchain_config(
         "-L{}libcxx-msan/lib/{}".format(target_toolchain_path_prefix, target_system_name),
     ]
 
-    # MemorySanitizer compile+link flags. Unlike asan/ubsan/tsan, msan must swap
+    # MemorySanitizer compile+link flags. Unlike asan/lsan/ubsan/tsan, msan must swap
     # the C++ standard library for an instrumented libc++. On Linux this is
     # wired through a `msan` cc_feature (see the mutually-exclusive features
     # built near the cc_toolchain_config call), so that enabling it with
     # `--features=msan` is reset in the exec configuration (via --host_features)
     # and build tools stay uninstrumented.
     #
-    # asan/ubsan/tsan are provided by rules_cc's stock sanitizer cc_features
+    # asan/lsan/ubsan/tsan are provided by rules_cc's stock sanitizer cc_features
     # (defined in unix_cc_toolchain_config) and are likewise enabled via
-    # `--features=asan|ubsan|tsan`, so they are not wired up here.
+    # `--features=asan|lsan|ubsan|tsan`, so they are not wired up here.
     msan_sanitizer_flags = [
         "-fsanitize=memory",
         "-fsanitize-memory-track-origins",
@@ -844,8 +844,8 @@ def cc_toolchain_config(
         baked_link_stdlib_flags = default_link_search_flags
         baked_link_libs_stdlib = stdlib_link_libs
 
-    # asan/ubsan/tsan are rules_cc's stock sanitizer cc_features, enabled via
-    # `--features=asan|ubsan|tsan`. They link via a plain `-fsanitize=...`, which
+    # asan/lsan/ubsan/tsan are rules_cc's stock sanitizer cc_features, enabled via
+    # `--features=asan|lsan|ubsan|tsan`. They link via a plain `-fsanitize=...`, which
     # does not pull Clang's C++ sanitizer runtime, so C++ programs fail to link
     # (e.g. ubsan's vptr handlers, __ubsan_*_type_cache). Augment each stock
     # feature with `-fsanitize-link-c++-runtime`; ubsan additionally gets
@@ -862,11 +862,10 @@ def cc_toolchain_config(
     # build), and the use_* settings all match at once when they do. A single
     # select() keyed on several of them is then an ambiguous match and Bazel
     # fails analysis, so the flags are assembled from selects that each key on
-    # exactly one condition: what asan/ubsan/tsan share keys on
+    # exactly one condition: what asan/lsan/ubsan/tsan share keys on
     # use_common_sanitizer, what only ubsan needs keys on use_ubsan. msan is
     # not involved -- it is carried by the msan/nomsan cc_features below, not by
-    # a select() -- and rules_cc's stock `lsan` feature is not augmented here
-    # yet; see //toolchain/config for both.
+    # a select(); see //toolchain/config.
     sanitizer_compile_flags = select({
         str(Label("@toolchains_llvm//toolchain/config:use_ubsan")): [
             "-fsanitize=bounds",

--- a/toolchain/config/BUILD.bazel
+++ b/toolchain/config/BUILD.bazel
@@ -42,18 +42,19 @@ config_setting(
 # Sanitizers are enabled via Bazel features, not //toolchain/config flags:
 #
 #   --features=asan      (AddressSanitizer)
+#   --features=lsan      (LeakSanitizer)
 #   --features=ubsan     (UndefinedBehaviorSanitizer)
 #   --features=tsan      (ThreadSanitizer)
 #   --features=msan      (MemorySanitizer; Linux only)
 #
-# asan/ubsan/tsan are rules_cc's stock sanitizer cc_features. msan is wired up
+# asan/lsan/ubsan/tsan are rules_cc's stock sanitizer cc_features. msan is wired up
 # in cc_toolchain_config.bzl because it must swap in an instrumented libc++
 # (supplied via the `libcxx_url`/`libcxx_sha256` attributes of the LLVM
 # distribution repo). Using features (rather than flags) lets Bazel reset them
 # to `--host_features` in the exec configuration, so build tools stay
 # uninstrumented.
 #
-# The config_settings below match `--features=asan|ubsan|tsan` so
+# The config_settings below match `--features=asan|lsan|ubsan|tsan` so
 # cc_toolchain_config.bzl can `select()` extra flags onto the stock features
 # (the C++ sanitizer runtime, and ubsan's bounds/nullability checks). Matching
 # on `--features` keeps the exec-configuration reset: the extra flags are
@@ -72,19 +73,25 @@ config_setting(
 )
 
 config_setting(
+    name = "use_lsan",
+    values = {"features": "lsan"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
     name = "use_tsan",
     values = {"features": "tsan"},
     visibility = ["//visibility:public"],
 )
 
-# The three settings above are not mutually exclusive: `--features=asan
+# The four settings above are not mutually exclusive: `--features=asan
 # --features=ubsan` matches both. A select() may therefore only key on more
 # than one of them when every matching branch resolves to the same value, so
-# anything shared by asan/ubsan/tsan keys on this group instead, and anything
-# sanitizer-specific gets its own single-condition select().
+# anything shared by asan/lsan/ubsan/tsan keys on this group instead, and
+# anything sanitizer-specific gets its own single-condition select().
 #
-# The group holds the sanitizers that need the same treatment, not every
-# sanitizer, and it is expected to grow:
+# The group holds the sanitizers that need the same treatment, which is all
+# four of rules_cc's stock ones but not every sanitizer:
 #
 #   msan needs no config_setting of its own. It is driven entirely by the
 #   mutually-exclusive msan/nomsan cc_features in cc_toolchain_config.bzl, so
@@ -93,23 +100,19 @@ config_setting(
 #   itself rather than through `-fsanitize-link-c++-runtime`, and it is
 #   Linux-only, so the macOS runtime dylibs never apply.
 #
-#   lsan belongs here but is not wired up yet. rules_cc ships four stock
-#   sanitizer features -- asan, lsan, tsan, ubsan -- and there is no :use_lsan
-#   setting above, so `--features=lsan` gets no augmentation. On macOS the
-#   linked binary does reference @rpath/libclang_rt.lsan_osx_dynamic.dylib,
-#   which nothing then ships into runfiles: the same failure #769 fixed for the
-#   other three. Adding it is a behaviour change for lsan builds and wants its
-#   own test, so it is deliberately left to a follow-up.
-#
 # Newer sanitizers keep appearing (the LLVM distributions already carry an
 # rtsan runtime), so expect to extend this. Anything added here must keep every
-# select() keyed on exactly one condition.
+# select() keyed on exactly one condition, and a sanitizer with a macOS dynamic
+# runtime also needs its dylib in the sanitizer-runtime-libs filegroup that
+# internal/configure.bzl emits -- otherwise the binary references
+# @rpath/libclang_rt.<san>_osx_dynamic.dylib that nothing ships.
 selects.config_setting_group(
     name = "use_common_sanitizer",
     match_any = [
         ":use_asan",
-        ":use_ubsan",
+        ":use_lsan",
         ":use_tsan",
+        ":use_ubsan",
     ],
     visibility = ["//visibility:public"],
 )

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -818,6 +818,9 @@ filegroup(
         "{use_asan}": ["{root}:libclang_rt-asan-darwin"],
         "//conditions:default": [],
     }}) + select({{
+        "{use_lsan}": ["{root}:libclang_rt-lsan-darwin"],
+        "//conditions:default": [],
+    }}) + select({{
         "{use_ubsan}": ["{root}:libclang_rt-ubsan-darwin"],
         "//conditions:default": [],
     }}) + select({{
@@ -829,6 +832,7 @@ filegroup(
             suffix = suffix,
             root = target_toolchain_root,
             use_asan = str(Label("//toolchain/config:use_asan")),
+            use_lsan = str(Label("//toolchain/config:use_lsan")),
             use_ubsan = str(Label("//toolchain/config:use_ubsan")),
             use_tsan = str(Label("//toolchain/config:use_tsan")),
         )


### PR DESCRIPTION
Fixes #826.

## Summary

Wire rules_cc's stock `lsan` feature into the same augmentation path as asan, ubsan, and tsan:

- add `//toolchain/config:use_lsan` and include it in `use_common_sanitizer`
- add the Darwin `libclang_rt.lsan_osx_dynamic.dylib` filegroup and route it through `dynamic_runtime_lib`
- add an end-to-end `//:lsan_test` and run it with the Linux sanitizer tests
- add a focused macOS CI job using LLVM 22.1.8

The Darwin version pin is deliberate. On current macOS, LLVM 19.1.7, 20.1.8, and 21.1.8 all run `main` and then deadlock during LSan's exit check. The leak-check thread calls `dyld_shared_cache_iterate_text`, which lazily loads dyld introspection code and allocates while LSan holds its allocator lock. LLVM compiler-rt #182943 switched this path to `_dyld_get_dyld_header`; that fix was backported to LLVM 22, and LLVM 22.1.8 exits normally.

The configured action graph now contains a `SolibSymlink` whose declared input is `libclang_rt.lsan_osx_dynamic.dylib`, so the runtime is provisioned rather than merely found incidentally in the local execroot.

## Verification

On macOS arm64:

- LLVM 19.1.7: times out after completing `main`
- LLVM 20.1.8: times out after completing `main`
- LLVM 21.1.8: times out after completing `main`
- LLVM 22.1.8: `//:lsan_test` passes
- `//:sanitizer_combo_flags_test` passes
- `actionlint` and `git diff --check` pass

Upstream fix: https://github.com/llvm/llvm-project/pull/182943