### PR TITLE
Support LLVM prerelease distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ llvm.toolchain(
 )
 ```
 
+Prereleases can be selected by their exact version and supplied through
+`extra_llvm_distributions` in the same way. Following the common SemVer range
+convention, they are excluded from `latest`, `first`, and stable-only version
+requirements. A requirement explicitly opts in by naming a prerelease with
+the same major/minor/patch tuple; for example, `latest:>=23.1.0-rc1` can select
+`23.1.0-rc3`, while `latest:>=23` and `latest:>22` cannot:
+
+```starlark
+llvm.toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "23.1.0-rc3",
+    extra_llvm_distributions = {
+        "LLVM-23.1.0-rc3-Linux-ARM64.tar.xz": "02165e7811fcc015502f7be30f5887db0c8904947b3c620af4236e15f1669431",
+        "LLVM-23.1.0-rc3-Linux-X64.tar.xz": "76ec17df0b0401d9427dbaf6403c2dfc5b5daeda1553566def4139418a35f1",
+        "LLVM-23.1.0-rc3-macOS-ARM64.tar.xz": "d23dc0baf29225e2975447f29bbc98b4fc3779001e91adc4a5d7d95854681e79",
+    },
+)
+```
+
+Run `utils/extra_distributions.sh -v 23.1.0-rc3` to obtain the entries
+published for a particular prerelease. An asset is usable only when its
+filename contains that logical release version; LLVM occasionally publishes
+platform assets under a different product version.
+
 The following `WORKSPACE` snippet shows how to add a specific version for a specific target before
 the version was added to the bundled distribution data under
 [`toolchain/distributions/`](toolchain/distributions).

--- a/toolchain/internal/BUILD.bazel
+++ b/toolchain/internal/BUILD.bazel
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("llvm_distributions.bzl", "distributions_test_writer", "requirements_test_writer")
+load("llvm_distributions.bzl", "distributions_test_writer", "prerelease_test_writer", "requirements_test_writer")
 
 exports_files(["template.modulemap"])
 
@@ -48,4 +48,17 @@ diff_test(
     name = "llvm_requirements_test",
     file1 = "llvm_requirements_test.golden.txt",
     file2 = "llvm_requirements_test.output.txt",
+)
+
+prerelease_test_writer(
+    name = "llvm_prerelease_test_output",
+    testonly = True,
+    result = "llvm_prerelease_test.output.txt",
+    visibility = ["//visibility:private"],
+)
+
+diff_test(
+    name = "llvm_prerelease_test",
+    file1 = "llvm_prerelease_test.golden.txt",
+    file2 = "llvm_prerelease_test.output.txt",
 )

--- a/toolchain/internal/distributions_repo.bzl
+++ b/toolchain/internal/distributions_repo.bzl
@@ -175,7 +175,11 @@ def _basename_version(basename):
     # Mirrors `_distribution_version_string` in `llvm_distributions.bzl`,
     # duplicated here to avoid a dependency cycle (this is a repository rule
     # that runs at fetch time, before the runtime module loads).
-    return basename.split("-", 2)[1]
+    parts = basename.split("-")
+    version = parts[1]
+    if len(parts) > 2 and parts[2].startswith("rc") and parts[2][2:].isdigit():
+        version += "-" + parts[2]
+    return version
 
 def _impl(rctx):
     distributions = {}

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -60,7 +60,7 @@ _llvm_distribution_urls = LLVM_DISTRIBUTION_URLS
 _DEFAULT_URL_TEMPLATE = "https://github.com/llvm/llvm-project/releases/download/llvmorg-{version}/"
 
 def _parse_version(v):
-    return tuple([int(s) for s in v.split(".")])
+    return tuple(versions.parse(v))
 
 def _version_string(version):
     return ".".join([str(v) for v in version])
@@ -72,7 +72,51 @@ def _distribution_version_string(distribution):
     # We assume here that the `distribution` contains a basename of the forms:
     # - `LLVM-<version>-...`, or
     # - `clang+llvm-<version>-...`.
-    return _distribution_basename(distribution).split("-", 2)[1]
+    parts = _distribution_basename(distribution).split("-")
+    version = parts[1]
+    if len(parts) > 2 and parts[2].startswith("rc") and parts[2][2:].isdigit():
+        version += "-" + parts[2]
+    return version
+
+def _is_prerelease(version):
+    return "-" in version
+
+def _parsed_version_core(parsed):
+    core = []
+    for part in parsed:
+        if part in ["-", "+"]:
+            break
+        core.append(part)
+    return tuple(core)
+
+def _version_core(version):
+    return _parsed_version_core(_parse_version(version))
+
+def _requirements_allow_prerelease(version, requirements):
+    if not _is_prerelease(version):
+        return True
+    if not requirements:
+        return False
+    core = _version_core(version)
+    return any([
+        "-" in requirement.version and _parsed_version_core(requirement.version) == core
+        for requirement in requirements
+    ])
+
+def _sort_versions(version_strings, *, reverse):
+    result = []
+    for version in version_strings:
+        inserted = False
+        for pos in range(len(result)):
+            if versions.cmp(result[pos], version) >= 0:
+                result = result[:pos] + [version] + result[pos:]
+                inserted = True
+                break
+        if not inserted:
+            result.append(version)
+    if reverse:
+        result = result[::-1]
+    return result
 
 def _distribution_version(distribution):
     # Return the version string of a distribution.
@@ -541,15 +585,22 @@ def _parse_version_or_requirements(version_or_requirements):
 def _get_version_from_distribution(distribution):
     # We assume here that the `distribution` is a basename of the form `LLVM-<version>-...` or
     # `clang+llvm-<version>-...`.
-    return distribution.split("-")[1]
+    return _distribution_version_string(distribution)
 
 def _get_llvm_versions(*, version_or_requirements, all_llvm_distributions):
+    requirements = _parse_version_or_requirements(version_or_requirements)
     llvm_version_dict = {}
     for distribution in all_llvm_distributions.keys():
         version = _get_version_from_distribution(distribution)
-        llvm_version_dict[_parse_version(version)] = version
 
-    return [v for k, v in sorted(llvm_version_dict.items(), reverse = version_or_requirements.startswith("latest"))]
+        # Match the common SemVer range convention: prereleases are excluded
+        # unless a comparator explicitly mentions a prerelease with the same
+        # major/minor/patch tuple.
+        if not _requirements_allow_prerelease(version, requirements):
+            continue
+        llvm_version_dict[version] = None
+
+    return _sort_versions(llvm_version_dict.keys(), reverse = version_or_requirements.startswith("latest"))
 
 def _required_llvm_release_name(*, version_or_requirements, all_llvm_distributions, host_info):
     llvm_versions = _get_llvm_versions(version_or_requirements = version_or_requirements, all_llvm_distributions = all_llvm_distributions)
@@ -998,6 +1049,55 @@ def _requirements_test_writer_impl(ctx):
 
 requirements_test_writer = rule(
     implementation = _requirements_test_writer_impl,
+    attrs = {
+        "result": attr.output(mandatory = True),
+    },
+)
+
+def _prerelease_test_writer_impl(ctx):
+    distributions = {
+        "LLVM-23.0.0-Linux-X64.tar.xz": "0" * 64,
+        "LLVM-23.1.0-rc2-Linux-X64.tar.xz": "1" * 64,
+        "LLVM-23.1.0-rc3-Linux-X64.tar.xz": "2" * 64,
+    }
+    host = struct(
+        arch = "x86_64",
+        os = "linux",
+        dist = struct(name = "ubuntu", version = "24.04"),
+    )
+    result = []
+
+    for requested in ["23.1.0-rc2", "23.1.0-rc3", "23.0.0"]:
+        available = _get_all_llvm_distributions(
+            llvm_distributions = distributions,
+            extra_llvm_distributions = {},
+            parsed_llvm_version = _parse_version(requested),
+        )
+        basename, error = _find_llvm_basename_or_error(requested, available, host)
+        result.append("exact {version}: {result}".format(
+            version = requested,
+            result = error or basename,
+        ))
+
+    all_distributions = _get_all_llvm_distributions(
+        llvm_distributions = distributions,
+        extra_llvm_distributions = {},
+        parsed_llvm_version = None,
+    )
+    for requested in ["latest", "latest:>=23", "latest:>22", "latest:>=23.1.0-rc1"]:
+        version, basename, error = _required_llvm_release_name(
+            version_or_requirements = requested,
+            all_llvm_distributions = all_distributions,
+            host_info = host,
+        )
+        result.append("{requested}: {result}".format(
+            requested = requested,
+            result = error or "{} = {}".format(version, basename),
+        ))
+    ctx.actions.write(ctx.outputs.result, "\n".join(result) + "\n")
+
+prerelease_test_writer = rule(
+    implementation = _prerelease_test_writer_impl,
     attrs = {
         "result": attr.output(mandatory = True),
     },

--- a/toolchain/internal/llvm_prerelease_test.golden.txt
+++ b/toolchain/internal/llvm_prerelease_test.golden.txt
@@ -1,0 +1,7 @@
+exact 23.1.0-rc2: LLVM-23.1.0-rc2-Linux-X64.tar.xz
+exact 23.1.0-rc3: LLVM-23.1.0-rc3-Linux-X64.tar.xz
+exact 23.0.0: LLVM-23.0.0-Linux-X64.tar.xz
+latest: 23.0.0 = LLVM-23.0.0-Linux-X64.tar.xz
+latest:>=23: 23.0.0 = LLVM-23.0.0-Linux-X64.tar.xz
+latest:>22: 23.0.0 = LLVM-23.0.0-Linux-X64.tar.xz
+latest:>=23.1.0-rc1: 23.1.0-rc3 = LLVM-23.1.0-rc3-Linux-X64.tar.xz

--- a/utils/extra_distributions.sh
+++ b/utils/extra_distributions.sh
@@ -21,7 +21,7 @@
 # `llvm_version` and let the toolchain pick the existing entries up.
 #
 # Usage: utils/extra_distributions.sh [-d] [-t <tempdir>] -v <version>
-#   -v <version>  LLVM release version (e.g. 19.1.0).
+#   -v <version>  LLVM release version (e.g. 19.1.0 or 23.1.0-rc3).
 #   -d            Force download tarballs and recompute SHA-256s locally
 #                 even when GitHub provides a .digest field.
 #   -t <tempdir>  Reuse a specific temp directory (kept after exit).
@@ -93,9 +93,10 @@ curl "${curl_args[@]}" \
 
 # Asset table: name <TAB> digest (may be empty) <TAB> download URL.
 assets_tsv="${tmp_dir}/assets.tsv"
-jq -r '
+jq -r --arg version "${llvm_version}" '
   .assets[]
   | select(.name | test("^(clang[+]llvm|LLVM)-.*tar.(xz|gz)$"))
+  | select(.name | contains("-" + $version + "-"))
   | [.name, ((.digest // "") | sub("^sha256:"; "")), .browser_download_url] | @tsv
 ' "${release_json}" >"${assets_tsv}"
 


### PR DESCRIPTION
## Summary

- parse LLVM RC versions from release asset names and generate the matching `llvmorg-<version>` download URL
- allow exact prerelease selection and SemVer-style explicit prerelease range opt-in
- teach `extra_distributions.sh` to handle prerelease versions and ignore mismatched asset versions
- document LLVM 23.1.0-rc3 configuration

Broad stable ranges remain stable-only: `latest:>=23` and `latest:>22` do not select an RC. A comparator such as `latest:>=23.1.0-rc1` explicitly opts into prereleases for the `23.1.0` tuple.

## Tests

- `bazel test //toolchain/internal:llvm_prerelease_test //toolchain/internal:llvm_requirements_test //toolchain/internal:llvm_distributions_output_test`
- `buildifier -mode=check -lint=warn ...`
- `shellcheck utils/extra_distributions.sh`
- `git diff --check`