### PR TITLE
Add LLVM 23.1.0 release

### DIFF
--- a/toolchain/distributions/github.jsonc
+++ b/toolchain/distributions/github.jsonc
@@ -24,6 +24,11 @@
     }
   },
 
+  // 23.1.0
+  "LLVM-23.1.0-Linux-ARM64.tar.zst": "50c0ba826e5571f0860e197a47369f20c68d723de650b8de7422af165b349513",
+  "LLVM-23.1.0-Linux-X64.tar.zst": "1a3dd8e99df9fe6f5b3b9c62a4a81e0c57da9b95b1889a6dbf6c304c264e756f",
+  "clang+llvm-23.1.0-x86_64-pc-windows-msvc.tar.zst": "1aebf024b959b3835c3bd936da2fa58cd002c61ccf47fce1714447b900bd9837",
+
   // 23.1.0-rc3
   "LLVM-23.1.0-rc3-Linux-ARM64.tar.zst": "df134d97038d8a6e377c1f4cd9a2bfe69b7a9b5fe4180ea484fedd4a395dc21e",
   "LLVM-23.1.0-rc3-Linux-X64.tar.zst": "4a1b03046ee7a5eb03ea65bd7389f698d800abec9da4e3864ab3908d64283f9a",

--- a/toolchain/internal/llvm_distributions.golden.out.txt
+++ b/toolchain/internal/llvm_distributions.golden.out.txt
@@ -92,6 +92,7 @@ version: 22.1.5
 version: 22.1.6
 version: 22.1.7
 version: 22.1.8
+version: 23.1.0
 version: 23.1.0-rc3
 del: clang+llvm-15.0.2-x86_64-unknown-linux-gnu-sles15.tar.xz
 del: clang+llvm-19.1.0-x86_64-pc-windows-msvc.tar.xz

--- a/toolchain/internal/llvm_prerelease_test.golden.txt
+++ b/toolchain/internal/llvm_prerelease_test.golden.txt
@@ -1,8 +1,8 @@
 exact 23.1.0-rc3: LLVM-23.1.0-rc3-Linux-X64.tar.zst
 exact 22.1.8: LLVM-22.1.8-Linux-X64.tar.xz
-latest: 22.1.8 = LLVM-22.1.8-Linux-X64.tar.xz
-latest:>=23: ERROR: No matching distribution found.
-latest:>22: 22.1.8 = LLVM-22.1.8-Linux-X64.tar.xz
-latest:>=23.1.0-rc1: 23.1.0-rc3 = LLVM-23.1.0-rc3-Linux-X64.tar.zst
+latest: 23.1.0 = LLVM-23.1.0-Linux-X64.tar.zst
+latest:>=23: 23.1.0 = LLVM-23.1.0-Linux-X64.tar.zst
+latest:>22: 23.1.0 = LLVM-23.1.0-Linux-X64.tar.zst
+latest:>=23.1.0-rc1: 23.1.0 = LLVM-23.1.0-Linux-X64.tar.zst
 custom-only latest: 20.1.4 = LLVM-20.1.4-Linux-X64.tar.zst
 custom-only bundled URL: suppressed


### PR DESCRIPTION
## Summary

- add LLVM 23.1.0 Linux ARM64, Linux X64, and Windows x86_64 distributions
- update generated distribution and requirement-resolution golden files

The upstream macOS artifact has not been published yet. This PR can be updated with it when available; the next toolchains_llvm release should wait for that asset.

## Testing

- `bazel test //toolchain/internal:all`
- commit-time Trunk checks