### PR TITLE
Migrate bzl dependency to mboworks_bzl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,7 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "platforms", version = "1.0.0")
-bazel_dep(name = "helly25_bzl", version = "0.4.3")
+bazel_dep(name = "mboworks_bzl", version = "0.5.1")
 
 llvm_distributions_ext = use_extension(
     "//toolchain/extensions:distributions.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,10 +19,10 @@ workspace(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "helly25_bzl",
-    sha256 = "5f817f3f032ed377675564716bd0c59c6c7e5bce5857ce1004112fa34c9b3394",
-    strip_prefix = "bzl-0.5.0",
-    url = "https://github.com/helly25/bzl/releases/download/0.5.0/bzl-0.5.0.tar.gz",
+    name = "mboworks_bzl",
+    sha256 = "0c51edbd3a3b69ebff59b5ffec411a3ab8cb137a845b9bba9803738cd7bd5c28",
+    strip_prefix = "bzl-0.5.1",
+    url = "https://github.com/mboworks/bzl/releases/download/0.5.1/bzl-0.5.1.tar.gz",
 )
 
 # Materialize the merged LLVM distribution table for WORKSPACE-mode builds

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@helly25_bzl//bzl/paths:paths.bzl", "paths")
+load("@mboworks_bzl//bzl/paths:paths.bzl", "paths")
 
 # buildifier: disable=bzl-visibility
 load(

--- a/toolchain/deps.bzl
+++ b/toolchain/deps.bzl
@@ -50,11 +50,11 @@ def bazel_toolchain_dependencies():
             url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.51.0/bazel_features-v1.51.0.tar.gz",
         )
 
-    # Load helly25_bzl for version comparisons.
-    if not native.existing_rule("helly25_bzl"):
+    # Load mboworks_bzl for version comparisons.
+    if not native.existing_rule("mboworks_bzl"):
         http_archive(
-            name = "helly25_bzl",
-            url = "https://github.com/helly25/bzl/releases/download/0.5.0/bzl-0.5.0.tar.gz",
-            sha256 = "5f817f3f032ed377675564716bd0c59c6c7e5bce5857ce1004112fa34c9b3394",
-            strip_prefix = "bzl-0.5.0",
+            name = "mboworks_bzl",
+            url = "https://github.com/mboworks/bzl/releases/download/0.5.1/bzl-0.5.1.tar.gz",
+            sha256 = "0c51edbd3a3b69ebff59b5ffec411a3ab8cb137a845b9bba9803738cd7bd5c28",
+            strip_prefix = "bzl-0.5.1",
         )

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@helly25_bzl//bzl/paths:paths.bzl", "paths")
+load("@mboworks_bzl//bzl/paths:paths.bzl", "paths")
 
 SUPPORTED_TARGETS = [
     ("linux", "x86_64"),

--- a/toolchain/internal/configure.bzl
+++ b/toolchain/internal/configure.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_features//:features.bzl", "bazel_features")
-load("@helly25_bzl//bzl/paths:paths.bzl", "paths")
+load("@mboworks_bzl//bzl/paths:paths.bzl", "paths")
 load(
     "//toolchain:aliases.bzl",
     _aliased_libs = "aliased_libs",

--- a/toolchain/internal/llvm_distributions.bzl
+++ b/toolchain/internal/llvm_distributions.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "use_netrc")
-load("@helly25_bzl//bzl/versions:versions.bzl", "versions")
 load(
     "@llvm_distributions_data//:data.bzl",
     "LLVM_DISTRIBUTIONS",
     "LLVM_DISTRIBUTION_URLS",
 )
+load("@mboworks_bzl//bzl/versions:versions.bzl", "versions")
 load(
     "//toolchain/internal:common.bzl",
     "attr_dict",

--- a/toolchain/internal/system_module_map.bzl
+++ b/toolchain/internal/system_module_map.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@bazel_features//:features.bzl", "bazel_features")
-load("@helly25_bzl//bzl/paths:paths.bzl", "paths")
+load("@mboworks_bzl//bzl/paths:paths.bzl", "paths")
 
 def _textual_header(file, *, include_prefixes, execroot_prefix):
     path = file.path


### PR DESCRIPTION
## Summary

- replace the `helly25_bzl` module and repository name with `mboworks_bzl`
- update bzlmod to `mboworks_bzl` 0.5.1
- update legacy WORKSPACE dependencies to the `mboworks/bzl` 0.5.1 release archive
- migrate all Starlark load labels to the renamed repository

## Testing

- `bazel test //toolchain/internal:all`
- `bazel test --enable_bzlmod=false //toolchain/internal:all`
- commit-time Trunk checks