### PR TITLE
Replace Ubuntu 20.04 in BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,7 @@
 matrix:
   bazel: [7.*, 8.*]
-  platform: [ubuntu2004, ubuntu2404, macos, macos_arm64]
+  # LLVM 19.1.7 requires glibc/libstdc++ versions newer than Ubuntu 20.04.
+  platform: [ubuntu2204, ubuntu2404, macos, macos_arm64]
 tasks:
   verify_targets:
     name: Verify build targets
@@ -13,7 +14,8 @@ bcr_test_module:
   module_path: tests
   matrix:
     bazel: [7.*, 8.*]
-    platform: [ubuntu2004, ubuntu2404, macos, macos_arm64]
+    # Keep in sync with the module verification platforms above.
+    platform: [ubuntu2204, ubuntu2404, macos, macos_arm64]
   tasks:
     run_test_module:
       name: Run test module


### PR DESCRIPTION
## Problem

The toolchains_llvm 1.9.0 BCR presubmit fails on Ubuntu 20.04. The selected upstream LLVM 19.1.7 executable requires `GLIBC_2.32`–`2.34` and `GLIBCXX_3.4.29`–`3.4.30`, which Ubuntu 20.04 does not provide. The Buildkite retry failed identically.

Tracking:
- BCR publication: bazelbuild/bazel-central-registry#10311
- failing Buildkite job: https://buildkite.com/bazel/bcr-presubmit/builds/40390/list?sid=01a04f6c-3f1e-4a29-b329-4046b86bf11b&tab=output
- direct publication-branch patch: bazel-contrib/bazel-central-registry#7

## Change

- replace only `ubuntu2004` with `ubuntu2204` in both BCR matrices
- document the LLVM/glibc compatibility reason inline
- document that the test-module platform list must remain synchronized

## Non-goals

This does not add Bazel versions or broaden the platform matrix beyond the single Ubuntu replacement.

## Validation

- `.trunk/tools/trunk check .bcr/presubmit.yml`