### PR TITLE
Add dependency-safe LLVM distribution tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,25 @@ The toolchain is tested to work with `rules_go`, `rules_rust`, and
 
 ### Accessing tools
 
+Dependency modules that need files from a matching LLVM distribution, but do
+not own the root module's C++ toolchain selection, can materialize only the
+distribution:
+
+```python
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.distribution(
+    name = "my_rule_llvm",
+    llvm_version = "22.1.8",
+)
+use_repo(llvm, "my_rule_llvm")
+```
+
+The generated repository uses the same `BUILD.llvm_repo.tpl` layout as the
+`<toolchain-name>_llvm` repository created by `llvm.toolchain`. It neither
+creates nor registers a C++ toolchain. Repository names must be globally unique
+among modules using this extension; a rule set should therefore include its
+module name in `name`.
+
 The LLVM distribution also provides several tools like `clang-format`. You can
 depend on these tools directly in the bin directory of the distribution. When
 not using the `toolchain_roots` attribute, the distribution is available in the

--- a/tests/scripts/ubuntu_install_libtinfo.sh
+++ b/tests/scripts/ubuntu_install_libtinfo.sh
@@ -5,13 +5,17 @@
 # However, the LLVM binary releases hosted up upstream still target Ubuntu 18.04
 # as of this writing and contain binaries linked against `libtinfo5`.
 #
-# This script installs `libtinfo5` using the `.deb` from Ubuntu 22.04's PPAs:
-# https://packages.ubuntu.com/jammy-updates/amd64/libtinfo5/download
+# This script installs `libtinfo5` using the retained, immutable base `.deb`
+# from Ubuntu 22.04's archive. Do not use the latest `jammy-updates` version:
+# superseded update packages are removed and would make this URL expire.
+# https://packages.ubuntu.com/jammy/amd64/libtinfo5/download
 
 set -euo pipefail
 
 pkg="$(mktemp --suffix=.deb)"
 trap 'rm -f "${pkg}"' EXIT
 
-curl -L https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb -o "${pkg}"
+curl --fail --location --show-error \
+  https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb \
+  --output "${pkg}"
 sudo dpkg -i "${pkg}"

--- a/toolchain/extensions/llvm.bzl
+++ b/toolchain/extensions/llvm.bzl
@@ -1,7 +1,7 @@
 """LLVM extension for use with bzlmod"""
 
 load("@bazel_features//:features.bzl", "bazel_features")
-load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain")
+load("@toolchains_llvm//toolchain:rules.bzl", "llvm_toolchain", _llvm_distribution = "llvm")
 load(
     "@toolchains_llvm//toolchain/internal:repo.bzl",
     _llvm_config_attrs = "llvm_config_attrs",
@@ -52,8 +52,31 @@ def _constraint_dict(tags, name):
 
 def _llvm_impl_(module_ctx):
     for mod in module_ctx.modules:
-        if not mod.is_root:
-            fail("Only the root module can use the 'llvm' extension")
+        toolchain_tags = (
+            mod.tags.toolchain +
+            mod.tags.toolchain_root +
+            mod.tags.target_toolchain_root +
+            mod.tags.sysroot +
+            mod.tags.extra_compiler_files +
+            mod.tags.extra_linker_files +
+            mod.tags.extra_exec_compatible_with +
+            mod.tags.extra_target_compatible_with
+        )
+        if not mod.is_root and toolchain_tags:
+            fail("Only the root module can configure an LLVM toolchain; dependency modules may only use the distribution tag")
+        for distribution_attr in mod.tags.distribution:
+            attrs = {
+                key: getattr(distribution_attr, key)
+                for key in dir(distribution_attr)
+                if not key.startswith("_")
+            }
+            if attrs.get("llvm_version") and attrs.get("llvm_versions"):
+                fail("Exactly one of llvm_version or llvm_versions must be set")
+            if not attrs.get("llvm_versions"):
+                if not attrs.get("llvm_version"):
+                    fail("One of llvm_version or llvm_versions must be set")
+                attrs["llvm_versions"] = {"": attrs["llvm_version"]}
+            _llvm_distribution(**attrs)
         toolchain_names = []
         for toolchain_attr in mod.tags.toolchain:
             name = toolchain_attr.name
@@ -117,9 +140,19 @@ _attrs.pop("sysroot", None)
 _attrs.pop("extra_compiler_files_dict", None)
 _attrs.pop("extra_linker_files_dict", None)
 
+_distribution_attrs = dict(_llvm_repo_attrs)
+_distribution_attrs["name"] = attr.string(
+    mandatory = True,
+    doc = "Globally unique name for the generated LLVM distribution repository.",
+)
+
 llvm = module_extension(
     implementation = _llvm_impl_,
     tag_classes = {
+        "distribution": tag_class(
+            doc = "Downloads an LLVM distribution without configuring or registering a C++ toolchain. This tag may be used by dependency modules.",
+            attrs = _distribution_attrs,
+        ),
         "toolchain": tag_class(
             attrs = _attrs,
         ),


### PR DESCRIPTION
## Motivation

Rulesets may need headers or static libraries from an official LLVM distribution without owning the consuming workspace's C++ toolchain selection. Today the bzlmod extension rejects every tag from a non-root module, so such rulesets either duplicate the distribution downloader or require every consumer to recreate their repository.

This is the narrower dependency-safe alternative to allowing dependency modules to configure complete toolchains in #568. It avoids the unresolved question of which module owns toolchain registration and aliases.

## Changes

- add `llvm.distribution(...)`, backed by the existing `llvm` repository rule
- permit that tag in dependency modules while keeping every toolchain/configuration tag root-only
- normalize `llvm_version` exactly as the combined `llvm_toolchain` macro does
- document the API, generated repository layout, and globally unique naming requirement

The tag only downloads/materializes the distribution. It does not create or register a C++ toolchain.

## Validation

- a two-module Bazel 9.2.0 integration fixture successfully built a root alias to `@distribution_dep//:clang`, where the dependency module alone declared `llvm.distribution(name = "distribution_dep_llvm", llvm_version = "22.1.8")`
- focused distribution tests pass:
  - `//toolchain/internal:llvm_distributions_output_test`
  - `//toolchain/internal:llvm_distributions_select_test`
  - `//toolchain/internal:llvm_prerelease_test`
  - `//toolchain/internal:llvm_requirements_test`
- `buildifier` and `git diff --check` pass
