### PR TITLE
Fix Ubuntu libtinfo5 CI download

### DIFF
--- a/tests/scripts/ubuntu_install_libtinfo.sh
+++ b/tests/scripts/ubuntu_install_libtinfo.sh
@@ -5,13 +5,17 @@
 # However, the LLVM binary releases hosted up upstream still target Ubuntu 18.04
 # as of this writing and contain binaries linked against `libtinfo5`.
 #
-# This script installs `libtinfo5` using the `.deb` from Ubuntu 22.04's PPAs:
-# https://packages.ubuntu.com/jammy-updates/amd64/libtinfo5/download
+# This script installs `libtinfo5` using the retained, immutable base `.deb`
+# from Ubuntu 22.04's archive. Do not use the latest `jammy-updates` version:
+# superseded update packages are removed and would make this URL expire.
+# https://packages.ubuntu.com/jammy/amd64/libtinfo5/download
 
 set -euo pipefail
 
 pkg="$(mktemp --suffix=.deb)"
 trap 'rm -f "${pkg}"' EXIT
 
-curl -L https://mirrors.kernel.org/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb -o "${pkg}"
+curl --fail --location --show-error \
+  https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb \
+  --output "${pkg}"
 sudo dpkg -i "${pkg}"


### PR DESCRIPTION
## Problem

Ubuntu published a new Jammy libtinfo5 update and removed the superseded 6.3-2ubuntu0.2 package from the mirror. The shared Ubuntu CI setup consequently downloads a small error page and passes it to dpkg, causing every dependent Ubuntu job to fail before tests start.

This broke the post-merge master run for #843: https://github.com/bazel-contrib/toolchains_llvm/actions/runs/33689709711

## Fix

- download the retained, immutable Ubuntu 22.04 base package (6.3-2) from the official Ubuntu archive
- pass --fail to curl so an HTTP error fails at the download step instead of producing a misleading dpkg error
- document why the script must not pin a rolling jammy-updates package

## Validation

- replacement URL returns a 99 KB Debian binary package
- bash syntax check
- ShellCheck
- git diff --check
- repository commit checks