### PR TITLE
Fix: make standard library headers includable from modules

### DIFF
--- a/tests/cpp_modules/cpp20_module.cppm
+++ b/tests/cpp_modules/cpp20_module.cppm
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+module;
+
+// Check that standard library headers can be included from a module
+#include <cassert> 
+
 export module toolchains_llvm_test;
 
 export int answer() {
+  assert(true);
   return 42;
 }

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -807,12 +807,22 @@ def cc_toolchain_config(
         # keep the default (uninstrumented) stdlib and stay uninstrumented.
         cc_args(
             name = name + "_msan_compile_args",
-            actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+            actions = [
+                "@rules_cc//cc/toolchains/actions:compile_actions",
+                "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
+                "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
+                "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
+            ],
             args = msan_compile_include_flags + msan_sanitizer_flags,
         )
         cc_args(
             name = name + "_msan_cxx_args",
-            actions = ["@rules_cc//cc/toolchains/actions:cpp_compile_actions"],
+            actions = [
+                "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+                "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
+                "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
+                "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
+            ],
             args = msan_cxx_isystem_flags,
         )
         cc_args(
@@ -846,7 +856,12 @@ def cc_toolchain_config(
         if normal_compile_include_flags:
             cc_args(
                 name = name + "_nomsan_compile_args",
-                actions = ["@rules_cc//cc/toolchains/actions:compile_actions"],
+                actions = [
+                    "@rules_cc//cc/toolchains/actions:compile_actions",
+                    "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
+                    "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
+                    "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
+                ],
                 args = normal_compile_include_flags,
                 requires_any_of = [":" + name + "_not_msan"],
             )
@@ -854,7 +869,12 @@ def cc_toolchain_config(
         if default_cxx_isystem_flags:
             cc_args(
                 name = name + "_nomsan_cxx_args",
-                actions = ["@rules_cc//cc/toolchains/actions:cpp_compile_actions"],
+                actions = [
+                    "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+                    "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
+                    "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
+                    "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
+                ],
                 args = default_cxx_isystem_flags,
                 requires_any_of = [":" + name + "_not_msan"],
             )

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -30,6 +30,12 @@ load(
     _os_arch_pair = "os_arch_pair",
 )
 
+CPP_MODULE_ACTIONS = [
+    "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
+    "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
+    "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
+]
+
 # Bazel 4.* doesn't support nested starlark functions, so we cannot simplify
 # _fmt_flags() by defining it as a nested function.
 def _fmt_flags(flags, toolchain_path_prefix):
@@ -640,10 +646,7 @@ def cc_toolchain_config(
             name = name + "_relocatable_cpp_modules_args",
             actions = [
                 "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
-                "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
-                "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
-                "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
-            ],
+            ] + CPP_MODULE_ACTIONS,
             args = [
                 "-Xclang",
                 "-fmodule-file-home-is-cwd",
@@ -808,21 +811,15 @@ def cc_toolchain_config(
         cc_args(
             name = name + "_msan_compile_args",
             actions = [
-                "@rules_cc//cc/toolchains/actions:compile_actions",
-                "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
-                "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
-                "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
-            ],
+                "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+            ] + CPP_MODULE_ACTIONS,
             args = msan_compile_include_flags + msan_sanitizer_flags,
         )
         cc_args(
             name = name + "_msan_cxx_args",
             actions = [
                 "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
-                "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
-                "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
-                "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
-            ],
+            ] + CPP_MODULE_ACTIONS,
             args = msan_cxx_isystem_flags,
         )
         cc_args(
@@ -857,11 +854,8 @@ def cc_toolchain_config(
             cc_args(
                 name = name + "_nomsan_compile_args",
                 actions = [
-                    "@rules_cc//cc/toolchains/actions:compile_actions",
-                    "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
-                    "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
-                    "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
-                ],
+                    "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+                ] + CPP_MODULE_ACTIONS,
                 args = normal_compile_include_flags,
                 requires_any_of = [":" + name + "_not_msan"],
             )
@@ -871,10 +865,7 @@ def cc_toolchain_config(
                 name = name + "_nomsan_cxx_args",
                 actions = [
                     "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
-                    "@rules_cc//cc/toolchains/actions:cpp20_module_compile",
-                    "@rules_cc//cc/toolchains/actions:cpp20_module_codegen",
-                    "@rules_cc//cc/toolchains/actions:cpp_module_deps_scanning",
-                ],
+                ] + CPP_MODULE_ACTIONS,
                 args = default_cxx_isystem_flags,
                 requires_any_of = [":" + name + "_not_msan"],
             )


### PR DESCRIPTION
When you try to include stdlib headers in a module, you end up with an error like this:

```
INFO: Analyzed target //src/tmp:tmp (0 packages loaded, 0 targets configured).
ERROR: /home/dev/.cache/bazel/_bazel_dev/081ca399a9bd900129a8f87351cbba8a/external/+std_module+std_module/BUILD.bazel:5:11: Deps scanning for std.cppm failed: (Exit 1): process-wrapper failed: error executing CppDepsScanning command 
  (cd /home/dev/.cache/bazel/_bazel_dev/081ca399a9bd900129a8f87351cbba8a/sandbox/processwrapper-sandbox/4/execroot/_main && \
  exec env - \
    DEPS_SCANNER_OUTPUT_FILE=bazel-out/k8-fastbuild/bin/external/+std_module+std_module/_objs/std/std.pic.ddi \
    PATH=/bin:/usr/bin:/usr/local/bin \
    PWD=/proc/self/cwd \
    TMPDIR=/tmp \
  /home/dev/.cache/bazel/_bazel_dev/install/3e6f3b7d6fdac67aed908160850e082b/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/home/dev/.cache/bazel/_bazel_dev/081ca399a9bd900129a8f87351cbba8a/sandbox/processwrapper-sandbox/4/stats.out' external/toolchains_llvm++llvm+llvm_toolchain/bin/cpp_module_deps_scanner.sh -U_FORTIFY_SOURCE '--target=x86_64-unknown-linux-gnu' -U_FORTIFY_SOURCE -fstack-protector -fno-omit-frame-pointer -fcolor-diagnostics -Wall -Wthread-safety -Wself-assign -Bexternal/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/ -resource-dir external/toolchains_llvm++llvm+llvm_toolchain_llvm/lib/clang/23 '-std=c++17' -MD -MF bazel-out/k8-fastbuild/bin/external/+std_module+std_module/_objs/std/std.pic.ddi.d '-frandom-seed=bazel-out/k8-fastbuild/bin/external/+std_module+std_module/_objs/std/std.pic.ddi' -iquote external/+std_module+std_module -iquote bazel-out/k8-fastbuild/bin/external/+std_module+std_module '-std=c++26' -Wno-reserved-module-identifier -c external/+std_module+std_module/std.cppm -o bazel-out/k8-fastbuild/bin/external/+std_module+std_module/_objs/std/std.pic.ddi -no-canonical-prefixes -Wno-builtin-macro-redefined '-D__DATE__="redacted"' '-D__TIMESTAMP__="redacted"' '-D__TIME__="redacted"' -Xclang -fmodule-file-home-is-cwd -Xclang -fbuiltin-headers-in-system-modules -Xclang -fmodules-embed-all-files)
Diagnostics while scanning dependencies for 'external/+std_module+std_module/std.cppm':
external/+std_module+std_module/std.cppm:16:10: fatal error: '__config' file not found
Target //src/tmp:tmp failed to build
```

This is because the `cpp_module_deps_scanning` action doesn't get the `_nomsan_cxx_args` applied to it, which is what passes `-cxx-isystem` pointing to libc++. So `clang-scan-deps` was failing immediately when trying to include stdlib headers. Making the args apply to the module-related actions (same ones already listed for `_relocatable_cpp_modules_args`) fixes it.

This was assisted by AI (Gemini).